### PR TITLE
Adds analyzer - Recife v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
+.lsp/
 
 /clj-kondo
 **/.clj-kondo/.cache

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ clj_cmd = env clj
 .PHONY: build
 build:
 	mkdir -p target
-	$(clj_cmd) -X:depstar uberjar :jar target/recife.jar :sync-pom true :version '"0.4.0-SNAPSHOT"' :exclude '["clojure/.*", "lambdaisland/.*", "medley/.*", "tla_edn/.*", "alandipert/.*", "metosin/.*", "quil/.*", "tlc2/.*", "com/.*", "javax/.*", "org/.*", "pcal/.*", "tla2sany/.*", "tla2tex/.*", "util/.*", "malli/.*", "jogamp/.*", "natives/.*", "processing/.*", "cljsjs/.*", "icon/.*", "fipp/.*", "edamame/.*"]'
+	$(clj_cmd) -X:depstar uberjar :jar target/recife.jar :sync-pom true :version '"0.4.0"' :exclude '["clojure/.*", "lambdaisland/.*", "medley/.*", "tla_edn/.*", "alandipert/.*", "metosin/.*", "quil/.*", "tlc2/.*", "com/.*", "javax/.*", "org/.*", "pcal/.*", "tla2sany/.*", "tla2tex/.*", "util/.*", "malli/.*", "jogamp/.*", "natives/.*", "processing/.*", "cljsjs/.*", "icon/.*", "fipp/.*", "edamame/.*", "javassist/.*", "arrudeia/.*"]'
 
 .PHONY: deploy
 deploy:
@@ -12,3 +12,12 @@ deploy:
 .PHONY: test
 test:
 	clj -M:test
+
+.PHONY: start-components
+start-components:
+	docker-compose -f docker/compose.yml pull
+	docker-compose -f docker/compose.yml up -d
+
+.PHONY: stop-components
+stop-components:
+	docker-compose -f docker/compose.yml down

--- a/deps.edn
+++ b/deps.edn
@@ -9,13 +9,39 @@
                      lambdaisland/kaocha {:mvn/version "1.0-612"}
                      elle/elle {:mvn/version "0.1.2"}
                      ;; `unilog` is needed by `elle`.
-                     spootnik/unilog {:mvn/version "0.7.24"}}
+                     spootnik/unilog {:mvn/version "0.7.24"}
+
+                     ;; For implementation apps.
+                     cheshire/cheshire {:mvn/version "5.10.1"}
+                     metosin/reitit {:mvn/version "0.5.13"}
+                     integrant/integrant {:mvn/version "0.8.0"}
+                     ring/ring {:mvn/version "1.9.4"}
+                     com.github.seancorfield/next.jdbc {:mvn/version "1.2.674"}
+                     http-kit/http-kit {:mvn/version "2.5.3"}
+                     org.postgresql/postgresql {:mvn/version "42.2.23"}
+                     clj-http/clj-http {:mvn/version "3.12.3"}
+                     clj-http-fake/clj-http-fake {:mvn/version "1.0.3"}
+                     com.github.seancorfield/honeysql {:mvn/version "2.0.0-rc5"}
+                     metosin/muuntaja {:mvn/version "0.6.8"}}
         :extra-paths ["test"]}
   :test {:extra-deps {nubank/matcher-combinators {:mvn/version "3.1.4"}
                       lambdaisland/kaocha {:mvn/version "1.0-612"}
                       elle/elle {:mvn/version "0.1.2"}
                       ;; `unilog` is needed by `elle`.
-                      spootnik/unilog {:mvn/version "0.7.24"}}
+                      spootnik/unilog {:mvn/version "0.7.24"}
+
+                      ;; For implementation apps.
+                      cheshire/cheshire {:mvn/version "5.10.1"}
+                      metosin/reitit {:mvn/version "0.5.13"}
+                      integrant/integrant {:mvn/version "0.8.0"}
+                      ring/ring {:mvn/version "1.9.4"}
+                      com.github.seancorfield/next.jdbc {:mvn/version "1.2.674"}
+                      http-kit/http-kit {:mvn/version "2.5.3"}
+                      org.postgresql/postgresql {:mvn/version "42.2.23"}
+                      clj-http/clj-http {:mvn/version "3.12.3"}
+                      clj-http-fake/clj-http-fake {:mvn/version "1.0.3"}
+                      com.github.seancorfield/honeysql {:mvn/version "2.0.0-rc5"}
+                      metosin/muuntaja {:mvn/version "0.6.8"}}
          :extra-paths ["test"]
          :main-opts   ["-m" "kaocha.runner"]}}
 
@@ -25,6 +51,8 @@
   pfeodrippe/tla-edn {:mvn/version "0.6.0-SNAPSHOT"}
   alandipert/interpol8 {:mvn/version "0.0.3"}
   metosin/malli {:mvn/version "0.5.1"}
-  quil/quil {:mvn/version "3.1.0"}}
+  quil/quil {:mvn/version "3.1.0"}
+  com.cognitect/transit-clj {:mvn/version "1.0.324"}
+  pfeodrippe/arrudeia {:mvn/version "0.11.0-SNAPSHOT"}}
 
  :paths ["src"]}

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,9 @@
+version: '3.1'
+services:
+  postgres_partner_1:
+    image: 'postgres:13.3'
+    ports: ['5500:5432']
+    expose: [5500]
+    environment:
+      POSTGRES_DB: partner_1_db
+      POSTGRES_PASSWORD: example

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>pfeodrippe</groupId>
   <artifactId>recife</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <name>recife</name>
   <description/>
   <url>https://github.com/pfeodrippe/recife</url>
@@ -38,19 +38,9 @@
       <version>1.10.2</version>
     </dependency>
     <dependency>
-      <groupId>medley</groupId>
-      <artifactId>medley</artifactId>
-      <version>1.3.0</version>
-    </dependency>
-    <dependency>
       <groupId>lambdaisland</groupId>
       <artifactId>deep-diff2</artifactId>
       <version>2.0.108</version>
-    </dependency>
-    <dependency>
-      <groupId>pfeodrippe</groupId>
-      <artifactId>tla-edn</artifactId>
-      <version>0.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>alandipert</groupId>
@@ -58,14 +48,34 @@
       <version>0.0.3</version>
     </dependency>
     <dependency>
+      <groupId>pfeodrippe</groupId>
+      <artifactId>arrudeia</artifactId>
+      <version>0.11.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>metosin</groupId>
       <artifactId>malli</artifactId>
       <version>0.5.1</version>
     </dependency>
     <dependency>
+      <groupId>com.cognitect</groupId>
+      <artifactId>transit-clj</artifactId>
+      <version>1.0.324</version>
+    </dependency>
+    <dependency>
       <groupId>quil</groupId>
       <artifactId>quil</artifactId>
       <version>3.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>pfeodrippe</groupId>
+      <artifactId>tla-edn</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>medley</groupId>
+      <artifactId>medley</artifactId>
+      <version>1.3.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/recife/analyzer.clj
+++ b/src/recife/analyzer.clj
@@ -1,0 +1,113 @@
+(ns recife.analyzer
+  "Functions to help you compare your implementation with the generated
+  traces."
+  (:require
+   [arrudeia.core :as ar]
+   [recife.core :as r]))
+
+(defn analyze
+  [result {:keys [:init :implementation-mapping :number-of-traces :debug?]
+           :or {number-of-traces 20}}]
+  (loop [[trace & other-traces] (-> result
+                                    r/states-from-result
+                                    (r/random-traces-from-states number-of-traces))
+         trace-counter 0]
+    (when debug? (println :trace-counter trace-counter))
+    (let [implementation-step->model-step (->> implementation-mapping
+                                               (mapv (juxt (comp :step val) key))
+                                               (into {}))
+          ;; Reset semaphore.
+          _ (swap! ar/semaphore (constantly {:debug []}))
+          initial-global-state (dissoc (get-in trace [0 1]) ::r/procs)
+          steps (->> trace
+                     (drop 1)
+                     (mapv (comp :context :recife/metadata last))
+                     (mapv (fn [[step context]]
+                             (let [impl (implementation-mapping step)]
+                               [(:self context) {:context context
+                                                 :impl-step (:step impl)}]))))
+          ;; TODO: Stop any remaining proc so it does not leak. Exceptions should
+          ;; also kill them. Is this fixed as long we run all the steps?
+
+          ;; Refactor this, it's being used only to find the cancelled indexes.
+          proc-name->proc (->> steps
+                               (map first)
+                               distinct
+                               (mapv (fn [name]
+                                       ;; TODO: Find cancelled indexes using some other way.
+                                       [name {:proc-name name}]))
+                               (into {}))
+          cancelled-indexes (ar/find-cancelled-indexes (ar/parse-process-names proc-name->proc steps))
+          ;; Set initial state.
+          _ (init initial-global-state)
+          ;; Run the steps.
+          {:keys [:error? :results]}
+          (->> steps
+               (reduce (fn [{:keys [:idx :proc-name->proc] :as acc} [self {:keys [:impl-step :context]}]]
+                         (let [
+                               ;; Fetch attributes from the root map for this step.
+                               {:keys [:register :guard :reload? :handler :assertion]}
+                               (-> impl-step
+                                   implementation-step->model-step
+                                   implementation-mapping)
+
+                               params {:context context
+                                       :model-state (last (get trace (inc idx)))
+                                       :model-previous-state (last (get trace idx))}
+                               ;; Create a proc or return a existent proc.
+                               ;; `guard` is used for situations where you don't
+                               ;; want to register unnecessarily.
+                               proc (when (or (nil? guard)
+                                              (guard params))
+                                      (or (when register
+                                            (ar/register self (register params)))
+                                          (proc-name->proc self)))
+                               ;; Run step using arrudeia, internally it's async
+                               ;; and may hang our process if called for a step
+                               ;; which does not really exist.
+                               run-step-result
+                               (when proc
+                                 (ar/run-step [proc impl-step]
+                                              {:step-opts
+                                               (when (or reload?
+                                                         (contains? cancelled-indexes idx))
+                                                 {:cancel-execution? true})}))
+
+                               output-map
+                               {:output (if handler
+                                          (handler (assoc params :step-result run-step-result))
+                                          run-step-result)
+                                :impl-step impl-step
+                                :context context}
+
+                               {:keys [:expected :actual] :as assertion-result}
+                               (when assertion
+                                 (assertion (assoc output-map
+                                                   :model-state (last (get trace (inc idx)))
+                                                   :model-previous-state (last (get trace idx)))))]
+                           (if (when assertion
+                                 (or (and expected actual
+                                          (not= expected actual))
+                                     (not assertion-result)))
+                             (-> acc
+                                 (update :results conj
+                                         [(inc idx)
+                                          [self (merge output-map
+                                                       {:error {:code :assertion-failed
+                                                                :result assertion-result}})]])
+                                 (update :idx inc)
+                                 (update :proc-name->proc assoc self proc)
+                                 (assoc :error? true))
+                             (-> acc
+                                 (update :idx inc)
+                                 (update :results conj [(inc idx) [self output-map]])
+                                 (update :proc-name->proc assoc self proc)))))
+                       {:idx 0
+                        :results []
+                        :proc-name->proc {}}))]
+      (cond
+        ;; If error, return the results until first error (inclusive).
+        error? {:results (concat (take-while #(-> % last last :error nil?) results)
+                                 [(first (filter #(-> % last last :error) results))])
+                :trace trace}
+        (seq other-traces) (recur other-traces (inc trace-counter))))))

--- a/test/example/implementation/partner_1/app.clj
+++ b/test/example/implementation/partner_1/app.clj
@@ -1,0 +1,1372 @@
+(ns example.implementation.partner-1.app
+  "Implementation of `example.partner-1`.
+
+  Make sure components (e.g. db) are running, see README.
+
+  We divide this namespace in sections so we don't have to create tiny
+  namespaces where our code is scattered over multiple files."
+  (:require
+   [arrudeia.core :as ar]
+   [clj-http.client :as http]
+   [clj-http.fake :as http-fake]
+   [clojure.edn :as edn]
+   [example.partner-2 :as model]
+   [honey.sql :as sql]
+   [honey.sql.helpers :as h]
+   [integrant.core :as ig]
+   [muuntaja.core :as m]
+   [next.jdbc :as jdbc]
+   [next.jdbc.sql :as j-sql]
+   [org.httpkit.server :refer [run-server]]
+   [recife.core :as r]
+   [reitit.ring :as ring]
+   [reitit.ring.coercion :as rrc]
+   [reitit.ring.middleware.muuntaja :as muuntaja]
+   [medley.core :as medley]
+   [clojure.set :as set]
+   [recife.analyzer :as analyzer]))
+
+;;;;;;;;;;;;;;;;;;;; PARTNER ;;;;;;;;;;;;;;;;;;;;
+
+(defn partner-signup
+  "Sign up a company into our partner."
+  ([company]
+   (partner-signup company []))
+  ([{:keys [:company/name]} children]
+   (http/request {:method :post
+                  ;; For our sake, the identifier is just the company
+                  ;; name.
+                  :params (merge {:identifier name}
+                                 (when (seq children)
+                                   ;; We can only send children if they already
+                                   ;; have the partner id (created by the partner,
+                                   ;; we don't have control over this id).
+                                   ;; This is why we have to sign up the children
+                                   ;; first.
+                                   {:children children}))
+                  :url "http://partner.recife/signup"})))
+
+;;;;;;;;;;;;;;;;;;;; HANDLERS ;;;;;;;;;;;;;;;;;;;;
+
+(defn partner-send-companies-handler
+  "Send companies with no children to partner.
+  The partner will trigger the webhook."
+  [{:keys [:db]}]
+  (let [companies-no-children (->> (-> (h/select :*)
+                                       (h/from :company)
+                                       (h/where [:not-in
+                                                 :company.id
+                                                 (-> (h/select :parent_company_id)
+                                                     (h/from :company)
+                                                     (h/where [:not= :parent_company_id nil]))])
+                                       sql/format)
+                                   (jdbc/execute! db))]
+    (ar/with-label ::send-companies-with-no-children
+      (try
+        (mapv partner-signup companies-no-children)
+        (finally
+          (mapv #(j-sql/update! db :company
+                                {:was_sent_to_partner true}
+                                {:id (:company/id %)})
+                companies-no-children))))
+    ;; Always return ok after sending children companies to the partner,
+    ;; the interaction with it is asynchronous (via webhook).
+    {:status 200
+     :body "ok"}))
+
+(defonce partner-webhook-lock (atom false))
+
+(defn partner-webhook-handler
+  "Called by the partner and if it's a event type from creation, it sets
+  the partner id for a given company.
+  Then it sends available parent companies (now that you know children ids) to
+  be registered in the partner."
+  [{:keys [:db :body-params]}]
+  (let [{:keys [:event-type :company-identifier :id]} body-params]
+    (when (= event-type "create")
+      (ar/with-label ::handle-request
+        (j-sql/update! db :company
+                       {:partner_id id}
+                       {:name company-identifier}))
+      (loop [lock-acquired? (compare-and-set! partner-webhook-lock false true)]
+        (when-not lock-acquired?
+          (ar/with-label ::load-companies)
+          (recur (compare-and-set! partner-webhook-lock false true))))
+      (let [available-companies (->> (-> (h/select :parent.* [:child.partner_id :child_partner_id])
+                                         (h/from [:company :parent])
+                                         (h/join [:company :child] [:= :child.parent_company_id :parent.id])
+                                         (h/where [:not-exists
+                                                   (-> (h/select :child.partner_id)
+                                                       (h/from [:company :child])
+                                                       (h/where [:= :child.parent_company_id :parent.id]
+                                                                [:= :child.partner_id nil]))]
+                                                  [:= :parent.partner_id nil]
+                                                  [:= :parent.was_sent_to_partner nil])
+                                         sql/format)
+                                     (jdbc/execute! db)
+                                     (group-by :company/id))]
+        (ar/with-label ::load-companies available-companies)
+        (ar/with-label ::send-to-partner
+          (try
+            (mapv #(partner-signup (first (val %))
+                                   (mapv :company/child_partner_id (val %)))
+                  available-companies)
+            (finally
+              (mapv #(j-sql/update! db :company
+                                    {:was_sent_to_partner true}
+                                    {:id (key %)})
+                    available-companies)
+              (reset! partner-webhook-lock false))))))
+    {:status 200
+     :body "ok"}))
+
+(comment
+
+  (declare db)
+  (declare app)
+
+  (j-sql/find-by-keys db :company :all)
+
+  ;; Reset partner ids.
+  (j-sql/update! db :company {:partner_id nil} {:name "c4"})
+  (j-sql/update! db :company {:partner_id nil} {:name "c2"})
+
+  ;; Send companies.
+  (http/request {:method :post
+                 :headers {"fake-routes"
+                           (pr-str
+                            {"http://partner.recife/signup"
+                             {:post
+                              '(fn [_]
+                                 {:status 200 :body "ok"})}})}
+                 :url "http://localhost:3000/partner/send-companies"})
+
+
+  ;; Webhook handler.
+  (http/request {:method :post
+                 :form-params {:event-type "create"
+                               :company-identifier "c4"
+                               :id 50}
+                 :content-type :json
+                 :url "http://localhost:3000/partner/webhook"})
+
+  (http/request {:method :post
+                 :form-params {:event-type "create"
+                               :company-identifier "c2"
+                               :id 51}
+                 :content-type :json
+                 :url "http://localhost:3000/partner/webhook"})
+
+  (http/request {:method :post
+                 :form-params {:event-type "create"
+                               :company-identifier "c2"
+                               :id 51}
+                 :content-type :json
+                 :url "http://localhost:3000/partner/webhook"})
+
+  ;; DB data.
+  (j-sql/find-by-keys db :company :all)
+
+  ())
+
+(defn routes
+  []
+  [[""
+    ["/partner"
+     ["/send-companies" {:post partner-send-companies-handler}]
+     ["/webhook" {:post partner-webhook-handler}]]]])
+
+(def middleware-inject-components
+  {:name ::inject-components
+   :compile (fn [{:keys [:components]} _]
+              ;; Inject components to request map, (e.g. we can access
+              ;; `:db` directly in the handler).
+              (fn [handler]
+                (fn [req]
+                  (handler (merge req components)))))})
+
+(def middleware-fake-routes
+  "Should be used only for tests where you want to send fake routes
+  over the wire."
+  {:name ::fake-routes
+   :compile (fn [_ _]
+              (fn [handler]
+                (fn [req]
+                  (if-let [fake-routes (get-in req [:headers "fake-routes"])]
+                    (http-fake/with-fake-routes (eval (edn/read-string fake-routes))
+                      (handler req))
+                    (handler req)))))})
+
+(defn app
+  [components]
+  (ring/ring-handler
+   (ring/router
+    (routes)
+    {:data {:components components
+            :muuntaja m/instance
+            :middleware [middleware-inject-components
+                         middleware-fake-routes
+                         muuntaja/format-middleware
+                         rrc/coerce-exceptions-middleware
+                         rrc/coerce-request-middleware
+                         rrc/coerce-response-middleware]}})
+   (ring/routes
+    (ring/create-resource-handler
+     {:path "/"})
+    (ring/create-default-handler
+     {:not-found (constantly {:status 404 :body "Not found"})}))))
+
+;;;;;;;;;;;;;;;;;;;; SYSTEM ;;;;;;;;;;;;;;;;;;;;
+
+(defmethod ig/init-key ::server
+  [_ {:keys [:handler] :as opts}]
+  (run-server handler (-> opts (dissoc handler) (assoc :join? false))))
+
+(defmethod ig/halt-key! ::server
+  [_ server]
+  (server))
+
+(defmethod ig/init-key :handler/run-app
+  [_ {:keys [:db]}]
+  (app {:db db}))
+
+(defmethod ig/init-key :database.sql/connection
+  [_ db-spec]
+  (let [db (jdbc/get-datasource db-spec)]
+    ;; Create company table here for convenience..
+    (->> (-> (h/create-table :company :if-not-exists)
+             (h/with-columns [[:id :serial [:primary-key]]
+                              ;; `name` is our identifier, but in real world apps, we
+                              ;; would use an Tax ID.
+                              [:name [:varchar 128] [:not nil] :unique]
+                              [:parent_company_id :int nil]
+                              [:partner_id :int nil]
+                              [:was_sent_to_partner :boolean nil]
+                              [[:constraint :company_fk]
+                               [:foreign-key :parent_company_id]
+                               [:references [:company :id]]]])
+             sql/format)
+         (jdbc/execute! db))
+    db))
+
+(def config
+  {::server {:handler (ig/ref :handler/run-app) :port 3000}
+   :handler/run-app {:db (ig/ref :database.sql/connection)}
+   :database.sql/connection {:dbtype "postgres"
+                             :dbname "partner_1_db"
+                             :password "example"
+                             :user "postgres"
+                             :port 5500}})
+
+(defn -main []
+  (ig/init config))
+
+(do (when (some-> (resolve 'sys) bound?)
+      (ig/halt! (var-get (resolve 'sys))))
+    (def sys (-main))
+
+    (def db (:database.sql/connection sys)))
+
+(comment
+
+  ;; DONE: Call fake routes over the wire.
+  (http-fake/with-fake-routes {"http://partner.recife/signup"
+                               {:post
+                                (fn [_]
+                                  {:status 200 :body "ok"})}}
+    (-> (http/request {:method :post
+                       :url "http://localhost:3000/partner/send-companies"})))
+
+  (->> (-> (h/drop-table :company) sql/format)
+       (jdbc/execute! db))
+
+  (->> (-> (h/truncate :company) sql/format)
+       (jdbc/execute! db))
+
+  (j-sql/find-by-keys db :company :all)
+
+  (j-sql/insert-multi! db :company
+                       [:name]
+                       [["Olha"]])
+
+  (j-sql/insert-multi! db :company
+                       [:name :parent_company_id]
+                       [["Eita" (:company/id (first (j-sql/find-by-keys db :company {:name "Olha"})))]])
+
+  (j-sql/insert-multi! db :company
+                       [:name :parent_company_id]
+                       [["Abrabo" (:company/id (first (j-sql/find-by-keys db :company {:name "Olha"})))]])
+
+  (http-fake/with-fake-routes {"http://partner.recife/signup"
+                               {:post
+                                (fn [_]
+                                  {:status 200 :body "ok"})}}
+    ((app {:db db}) {:request-method :post, :uri "/partner/send-companies"}))
+
+  ;; TODO:
+  ;; - [x] Send initial data to partner.
+  ;; - [x] Use trace for sending requests to webhook.
+  ;; - [x] Webhook.
+  ;; - [x] Send parent companies.
+  ;; - [x] Check trace.
+  ;; - [x] Create a counterexample.
+
+  ())
+
+;; No violation found.
+(declare trace)
+
+;; Trace with some counterexample (violation).
+(declare c-trace)
+
+(comment
+
+  ;; TODO: Make it work for HTTP request so it's not
+  ;; bypassed. We have to make the control serializable from
+  ;; the wire somehow. For it we could have the arrudeia state
+  ;; in some storage (database or just atoms backed by files).
+  #_(http/request {:method :post
+                   :headers {"fake-routes"
+                             (pr-str
+                              {"http://partner.recife/signup"
+                               {:post
+                                '(fn [x]
+                                   {:status 200 :body "ok"})}})}
+                   :url "http://localhost:3000/partner/send-companies"})
+
+  (j-sql/find-by-keys db :company :all)
+
+  (def result
+    (r/run-model model/global
+                 #{model/initial-request
+                   model/partner-server
+                   model/webhook
+                   model/no-partner-history-duplicates
+                   model/all-companies-will-have-an-id}
+                 {:trace-example? true}))
+
+  ;; We cannot guarantee that the implementation is a refinement of the model,
+  ;; but we can say that it satisfies the model. One way to generate a counterexample
+  ;; is to deliberately create a trace which violates some invariant or property
+  ;; so it can be used in one of our tests.
+  (let [
+        ;; Receives initial global state from a trace.
+        init
+        (fn [{:keys [::model/companies]}]
+          ;; Reset lock.
+          (reset! partner-webhook-lock false)
+          ;; Remove all records for every new trace.
+          (->> (-> (h/truncate :company) sql/format)
+               (jdbc/execute! db))
+          ;; Insert all the companies according to initial global state.
+          (->> companies
+               (mapv (fn [[identifier]] [(name identifier)]))
+               (j-sql/insert-multi! db :company [:name]))
+          ;; Set parents for each child.
+          (->> companies
+               (mapv (fn [[identifier {:keys [:children]}]]
+                       (mapv #(j-sql/update! db :company
+                                             {:parent_company_id
+                                              (-> (j-sql/find-by-keys db :company
+                                                                      {:name (name identifier)})
+                                                  first
+                                                  :company/id)}
+                                             {:name (name %)})
+                             children)))))
+
+        ;; Mapping from model step to implementation lifecycle.
+        implementation-mapping
+        {::model/initial-request
+         {:step ::send-companies-with-no-children
+          :register (fn [_]
+                      (http-fake/with-fake-routes {"http://partner.recife/signup"
+                                                   {:post
+                                                    (fn [req]
+                                                      {:req req :status 200 :body "ok"})}}
+                        ((app {:db db})
+                         {:request-method :post
+                          :uri "/partner/send-companies"})))
+          :handler (fn [{:keys [:step-result]}]
+                     (->> step-result
+                          (mapv #(-> % :req :params :identifier keyword))))
+          ;; `:assertion` will be compared step by step, it's a optional parameter.
+          :assertion (fn [{:keys [:output]}]
+                       {:expected #{:c4 :c2}
+                        :actual (set output)})}
+
+         ;; `::model/partner-server` is one step we don't have
+         ;; control of, the code for this is in the partner
+         ;; server and we will use the trace state to
+         ;; call the webhook.
+         :partner/server
+         {:step ::partner-server}
+
+         :webhook/handle-request
+         {:step ::handle-request
+          ;; Guard for `:register` so it does not register something which is not
+          ;; going to be used.
+          :guard (fn [{:keys [:context]}] (some? (:req context)))
+          :register (fn [{:keys [:context]}]
+                      (let [[company-identifier partner-id] (:req context)]
+                        (http-fake/with-fake-routes {"http://partner.recife/signup"
+                                                     {:post
+                                                      (fn [req]
+                                                        {:req req :status 200 :body "ok"})}}
+                          ((app {:db db})
+                           {:request-method :post
+                            :uri "/partner/webhook"
+                            :body-params {:event-type "create"
+                                          :company-identifier (name company-identifier)
+                                          :id partner-id}}))))
+          ;; `:handler` can be used with register so you can, for example,
+          ;; get a snapshot of the database after the action was done like
+          ;; the function below.
+          :handler (fn [_]
+                     (->> (j-sql/find-by-keys db :company :all)
+                          (mapv (juxt (comp keyword :company/name)
+                                      #(-> %
+                                           (select-keys [:company/partner_id :company/was_sent_to_partner])
+                                           (set/rename-keys {:company/partner_id :id
+                                                             :company/was_sent_to_partner :sent?}))))
+                          (into {})))
+          :assertion (fn [{:keys [:model-state :output]}]
+                       {:expected (->> (::model/companies model-state)
+                                       (medley/map-vals #(merge {:id nil :sent? nil}
+                                                                (select-keys % [:id :sent?]))))
+                        :actual output})}
+
+         :webhook/load-companies
+         {:step ::load-companies
+          :handler (fn [_]
+                     (->> (j-sql/find-by-keys db :company :all)
+                          (mapv (juxt (comp keyword :company/name)
+                                      #(-> %
+                                           (select-keys [:company/partner_id :company/was_sent_to_partner])
+                                           (set/rename-keys {:company/partner_id :id
+                                                             :company/was_sent_to_partner :sent?}))))
+                          (into {})))}
+
+         :webhook/send-to-partner
+         {:step ::send-to-partner
+          :handler (fn [{:keys [:step-result]}]
+                     (->> step-result
+                          (mapv #(-> % :req :params :identifier keyword))))
+          ;; `:reload?` is used for the last step in a process if you want to indicate
+          ;; that step should be cancelled (would be fresh next time it's called).
+          :reload? true
+          :assertion (fn [{:keys [:model-state :model-previous-state :output]}]
+                       {:expected (:partner/reqs model-state)
+                        :actual (set/union (:partner/reqs model-previous-state) (set output))})}}]
+    (analyzer/analyze result
+                      {:init init
+                       :number-of-traces 10
+                       :implementation-mapping implementation-mapping}))
+
+  ;; TODO (PRIORITY):
+  ;; - [x] Convert the implementation runner to a generic function.
+
+  ;; TODO:
+  ;; - [ ] Make sure that it's easy to check pieces (e.g. init-fn etc) of your
+  ;;       trace checking.
+  ;; - [ ] It should also be easy to have the generated steps so the user can
+  ;;       run it independtly with arrudeia (instead of being constrained
+  ;;       to run everything or nothing, let the user run things in pieces).
+  ;; - [ ] Show better diff if inconsistency occurs.
+  ;; - [ ] Create clean `app` ns so we can create a version with the addition
+  ;;       of arrudeia later.
+  ;; - [ ] Add timeout.
+  ;; - [ ] Find some way to clear all the processes.
+
+  ;; TALK TODO:
+  ;; - [ ] Change the model so it creates a counterexample so you can add it
+  ;;       as one of your implementation tests.
+  ;; - [ ] Create schematic of what happens behind the scenes in Recife.
+  ;; - [ ] Create schematic of what happens in the analyzer (lifecycle).
+  ;; - [ ] It's not easy, you have to come with your own assertions about the model
+  ;;       and then create the mapping to the implementation, it requires some thought.
+  ;; - [ ] We can have a bidirectional feedback between model and implementation.
+
+  ())
+
+(def c-trace
+  [[0
+    {:recife.core/procs
+     {:initial-request {:pc :example.partner-2/initial-request},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/handle-request},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {},
+      :c3 {:children #{:c1}},
+      :c4 {}},
+     :id/counter 0,
+     :partner/history []}]
+   [1
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/handle-request},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{:c4 :c2},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 0,
+     :partner/history [],
+     :recife/metadata
+     {:context
+      [:example.partner-2/initial-request {:self :initial-request}]}}]
+   [2
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/handle-request},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{:c4},
+     :webhook/reqs #{[:c2 0]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 1,
+     :partner/history [[:c2 0]],
+     :recife/metadata
+     {:context [:partner/server {:req :c2, :self :p2}]}}]
+   [3
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/handle-request},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c2 0] [:c4 1]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :recife/metadata
+     {:context [:partner/server {:req :c4, :self :p2}]}}]
+   [4
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/load-companies},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c4 1]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :recife/metadata
+     {:context [:webhook/handle-request {:req [:c2 0], :self :w1}]}}]
+   [5
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/load-companies},
+      :w2 {:pc :webhook/load-companies}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :recife/metadata
+     {:context [:webhook/handle-request {:req [:c4 1], :self :w2}]}}]
+   [6
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}},
+      :w2 {:pc :webhook/load-companies}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :recife/metadata
+     {:context [:webhook/load-companies {:self :w1}]},
+     :global/locked? true}]
+   [7
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}},
+      :w2 {:pc :webhook/load-companies}},
+     :partner/reqs #{:c1},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :recife/metadata
+     {:context [:webhook/send-to-partner {:self :w1}]},
+     :global/locked? false}]
+   [8
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}},
+      :w2
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{:c1},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :recife/metadata
+     {:context [:webhook/load-companies {:self :w2}]},
+     :global/locked? true}]
+   [9
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}},
+      :w2
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c1 2]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 3,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2]],
+     :recife/metadata
+     {:context [:partner/server {:req :c1, :self :p2}]},
+     :global/locked? true}]
+   [10
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{:c1},
+     :webhook/reqs #{[:c1 2]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 3,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2]],
+     :recife/metadata
+     {:context [:webhook/send-to-partner {:self :w2}]},
+     :global/locked? false}]
+   [11
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c1 2] [:c1 3]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c1 3]],
+     :recife/metadata
+     {:context [:partner/server {:req :c1, :self :p2}]},
+     :global/locked? false}]])
+
+(def trace
+  [[0
+    {:recife.core/procs
+     {:initial-request {:pc :example.partner-2/initial-request},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/handle-request},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {},
+      :c3 {:children #{:c1}},
+      :c4 {}},
+     :id/counter 0,
+     :partner/history []}]
+   [1
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/handle-request},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{:c4 :c2},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 0,
+     :partner/history [],
+     :recife/metadata
+     {:context
+      [:example.partner-2/initial-request {:self :initial-request}]}}]
+   [2
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/handle-request},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{:c4},
+     :webhook/reqs #{[:c2 0]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 1,
+     :partner/history [[:c2 0]],
+     :recife/metadata
+     {:context [:partner/server {:req :c2, :self :p1}]}}]
+   [3
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/load-companies},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{:c4},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 1,
+     :partner/history [[:c2 0]],
+     :recife/metadata
+     {:context [:webhook/handle-request {:req [:c2 0], :self :w1}]}}]
+   [4
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1 {:pc :webhook/load-companies},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c4 1]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :recife/metadata
+     {:context [:partner/server {:req :c4, :self :p2}]}}]
+   [5
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2 {:pc :webhook/handle-request}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c4 1]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :global/locked? true,
+     :recife/metadata
+     {:context [:webhook/load-companies {:self :w1}]}}]
+   [6
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2 {:pc :webhook/load-companies}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :global/locked? true,
+     :recife/metadata
+     {:context [:webhook/handle-request {:req [:c4 1], :self :w2}]}}]
+   [7
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2 {:pc :webhook/load-companies}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:webhook/send-to-partner {:self :w1}]}}]
+   [8
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :global/locked? true,
+     :recife/metadata
+     {:context [:webhook/load-companies {:self :w2}]}}]
+   [9
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{:c1},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 2,
+     :partner/history [[:c2 0] [:c4 1]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:webhook/send-to-partner {:self :w2}]}}]
+   [10
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c1 2]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 3,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:partner/server {:req :c1, :self :p2}]}}]
+   [11
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/load-companies,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 3,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:webhook/handle-request {:req [:c1 2], :self :w2}]}}]
+   [12
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 3,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2]],
+     :global/locked? true,
+     :recife/metadata
+     {:context [:webhook/load-companies {:self :w2}]}}]
+   [13
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{:c3},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 3,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:webhook/send-to-partner {:self :w2}]}}]
+   [14
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{[:c3 3]},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:partner/server {:req :c3, :self :p2}]}}]
+   [15
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :partner/server},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/load-companies,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true, :id 3},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:webhook/handle-request {:req [:c3 3], :self :w2}]}}]
+   [16
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :recife.core/done},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/load-companies,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true, :id 3},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:partner/server {:req nil, :self :p1}]}}]
+   [17
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :recife.core/done},
+      :w1
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}, :sent? true, :id 3},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true, :id 3},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? true,
+     :recife/metadata
+     {:context [:webhook/load-companies {:self :w2}]}}]
+   [18
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :recife.core/done},
+      :w1
+      {:pc :recife.core/done,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/send-to-partner,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}, :sent? true, :id 3},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true, :id 3},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? true,
+     :recife/metadata
+     {:context [:webhook/handle-request {:req nil, :self :w1}]}}]
+   [19
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :partner/server},
+      :p1 {:pc :recife.core/done},
+      :w1
+      {:pc :recife.core/done,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}, :sent? true, :id 3},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true, :id 3},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:webhook/send-to-partner {:self :w2}]}}]
+   [20
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :recife.core/done},
+      :p1 {:pc :recife.core/done},
+      :w1
+      {:pc :recife.core/done,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :webhook/handle-request,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}, :sent? true, :id 3},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true, :id 3},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:partner/server {:req nil, :self :p2}]}}]
+   [21
+    {:recife.core/procs
+     {:initial-request {:pc :recife.core/done},
+      :p2 {:pc :recife.core/done},
+      :p1 {:pc :recife.core/done},
+      :w1
+      {:pc :recife.core/done,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}},
+        :c4 {:sent? true}}},
+      :w2
+      {:pc :recife.core/done,
+       :loaded-companies
+       {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+        :c2 {:sent? true, :id 0},
+        :c3 {:children #{:c1}, :sent? true, :id 3},
+        :c4 {:sent? true, :id 1}}}},
+     :partner/reqs #{},
+     :webhook/reqs #{},
+     :example.partner-2/companies
+     {:c1 {:children #{:c4 :c2}, :sent? true, :id 2},
+      :c2 {:sent? true, :id 0},
+      :c3 {:children #{:c1}, :sent? true, :id 3},
+      :c4 {:sent? true, :id 1}},
+     :id/counter 4,
+     :partner/history [[:c2 0] [:c4 1] [:c1 2] [:c3 3]],
+     :global/locked? false,
+     :recife/metadata
+     {:context [:webhook/handle-request {:req nil, :self :w2}]}}]])

--- a/test/example/implementation/wire_1.clj
+++ b/test/example/implementation/wire_1.clj
@@ -1,0 +1,150 @@
+(ns example.implementation.wire-1
+  "Very simple implementation of `hillel.ch1-wire-1` spec
+  se we can show how to call the \"real\" app with generated traces.
+
+  It's not supposed to be one on one with the specification, but it will be
+  very similar as it's a constrained example (we will have more complex ones,
+  this is just a good starting point).
+
+  We are interested in the app behaviour of a entire trace, we could have used the
+  implementation to drive the spec, but this is unrealistic as a real app will
+  comunicate with a real database or do requests, which will make the spec
+  check too slow for any practical purposes, so we are not going down this road.
+  "
+  (:require
+   [arrudeia.core :as ar]
+   [hillel.ch1-wire-1 :as model]
+   [recife.core :as r]
+   [medley.core :as medley]
+   [recife.analyzer :as analyzer]))
+
+;; This is our "DB".
+(def balances (atom {}))
+
+(defn- adapt
+  [args]
+  (update args :money bigdec))
+
+(defn- check-funds
+  [{:keys [:sender :money] :as args}]
+  ;; `arrudeia` is a library to help you with scheduling, `with-label`
+  ;; enables you to give a identifier (just a keyowrd) to this step (which
+  ;; is a arbitrary form) which will wait until it's enabled to run, see
+  ;; `comment` form below.
+  (ar/with-label ::check-funds
+    (when (< money (@balances sender))
+      args)))
+
+(defn- withdraw!
+  [{:keys [:sender :money] :as args}]
+  (ar/with-label ::withdraw!
+    (swap! balances update sender - money))
+  args)
+
+(defn- deposit!
+  [{:keys [:receiver :money] :as args}]
+  (ar/with-label ::deposit!
+    (swap! balances update receiver + money))
+  args)
+
+(defn request
+  [args]
+  ;; `check-funds` can return `nil`, which will short-circuit the
+  ;; pipeline.
+  (some-> (adapt args)
+          check-funds
+          withdraw!
+          deposit!)
+  @balances)
+
+(comment
+
+  (def result (r/run-model model/global #{model/wire model/invariant} {:fp 6
+                                                                       :seed -3669946775118883845}))
+
+  (do
+    (reset! balances {:alice 5M :bob 5M})
+    (def x (ar/register nil (request {:money 4
+                                      :sender :alice
+                                      :receiver :bob})))
+    (try
+      (ar/run-step [x ::check-funds])
+      (finally
+        (Thread/sleep 100)
+        (.close x))))
+
+  ;; Run it manually by looking at the generated violated trace.
+  (let [_ (reset! balances {:alice 5M :bob 5M})
+        x (ar/register :x (request {:money 4
+                                    :sender :alice
+                                    :receiver :bob}))
+        y (ar/register :y (request {:money 2
+                                    :sender :alice
+                                    :receiver :bob}))]
+    (ar/run-processes! [[y ::check-funds]
+                        [x ::check-funds]
+                        [y ::withdraw!]
+                        [x ::withdraw!]]
+                       ;; We pass a step handler which adapts the response
+                       ;; of this step, we are only interested on the balances so
+                       ;; we can compare the values of these with the trace violation.
+                       {:step-handler (fn [_] @balances)}))
+
+  (->> @ar/semaphore
+       :debug
+       (map-indexed vector))
+
+  ;; Automate it with some helpers.
+  ;; We have some main points which need to be addresses (TODO):
+  ;; - [x] Global initialization, what we need to call and how to adapt this data
+  ;; -     from the trace to `arrudeia`.
+  ;; - [x] Processes mapping, collect all the processes from the trace, map it
+  ;; -     and "initilize" with any needed local variables.
+  ;; - [x] Check impl global state with trace.
+  ;; - [x] Test with traces from the states file.
+  ;; - [x] Fix `arrudeia` in that it should not run the thread before any
+  ;;       command. ATM it's running until the first step, but this may be
+  ;;       underisable and hard to reason about.
+  ;; - [x] Deal with context parameters besides `:self`.
+  ;; - [x] Check impl local state with trace. Or maybe global state is enough?
+  ;; - [ ] Maybe make dynamic processes work (processes created after state `0`)?
+  ;; -     Do we need to assert the step which created the new process?
+  ;; - [ ] Maybe make a protocol out of this?
+  (def result
+    (r/run-model model/global #{model/wire model/invariant} {:fp 6
+                                                             :seed -3669946775118883845
+                                                             :dump-states? true}))
+
+  (let [init (fn [initial-global-state] (reset! balances initial-global-state))
+        implementation-mapping
+        (->> {::model/check-funds
+              {:step ::check-funds
+               :register (fn [{:keys [:context :model-previous-state]}]
+                           (let [amount (get-in model-previous-state [::r/procs (:self context) :amount])]
+                             (request {:money amount
+                                       :sender :account/alice
+                                       :receiver :account/bob})))}
+
+              ::model/deposit {:step ::deposit!}
+              ::model/withdraw {:step ::withdraw!}}
+             (medley/map-vals
+              (fn [m]
+                (assoc m
+                       :handler (fn [_] (medley/map-vals int @balances))
+                       :assertion (fn [{:keys [:model-state :output]}]
+                                    {:expected (dissoc model-state ::r/procs :recife/metadata)
+                                     :actual output})))))]
+    (analyzer/analyze result {:init init
+                              :implementation-mapping implementation-mapping
+                              :number-of-traces 100}))
+
+  ())
+
+(comment
+
+  ;; TODO:
+  ;; [x] - We are not interested only in the final result, but also in the
+  ;;       transient ones, so arrudeia can receive a function which adapts the
+  ;;       response for us.
+
+  ())

--- a/test/example/partner_1.clj
+++ b/test/example/partner_1.clj
@@ -1,0 +1,144 @@
+(ns example.partner-1
+  "This is a simple protocol for a integration which requires you to sign up
+  children before you sign up any parent entities, it's required you to know the
+  ids of the children beforehand (yes, it's a bad API design by our integration
+  partner, but which we have to deal with nonetheless). It's a simplification of
+  a real world spec which I wrote and found a violation, which made us change
+  the implementation.
+
+  Our entities are companies which can have children which also are companies,
+  so you can have grandchildren or great-grandchildren (but no loops, you cannot
+  have a child C1 who has a parent P1 where C1 has P1 as one of its children
+  (transitively or directly)).
+
+  See other `example.partner-*` namespaces for more checks and fixes.
+  "
+  (:require
+   [clojure.set :as set]
+   [recife.anim :as ra]
+   [recife.core :as r]))
+
+(def global
+  ;; All global keywords should be namespaced so we can differentiate it
+  ;; from local variables in our processes.
+  {
+   ;; `:c1`, `:c2` etc are the companies names (unique).
+   ;; `:children` are the children of that company.
+   ::companies {:c1 {:children #{:c2}}
+                :c2 {}
+                :c3 {:children #{:c1}}
+                :c4 {}}
+
+   ;; In the real world, we talk to our partner through a HTTP request, but here
+   ;; we don't need to bother about implementation details like status, HTTP library
+   ;; or error handling. We will model a API request by putting a element in a set,
+   ;; which the partner process will consume.
+   ;; Requests sent to the partner.
+   :partner/reqs #{}
+
+   ;; Requests sent to the webhook.
+   :webhook/reqs #{}
+
+   ;; Counter used by parter to give a id to an company.
+   :id/counter 0
+
+   ;; `:partner/history` stores the companies sent by the partner to the
+   ;; webhook.
+   :partner/history []})
+
+(r/defproc initial-request {}
+  (fn [{:keys [::companies] :as db}]
+    ;; Initially, send only the companies with no children as there is no
+    ;; `:id` that we can reference them in their parents.
+    (let [companies-with-no-children (->> companies
+                                          (remove (comp seq :children val))
+                                          keys
+                                          set)]
+      (-> db
+          (update :partner/reqs set/union companies-with-no-children)
+          ;; We want this step to happen only in the beginning, so we will "close" it
+          ;; with `r/done`.
+          (r/done)))))
+
+;; Represents the partner server, it just adds an id to the company and send it
+;; to the webhook, which will handle it.
+(r/defproc partner-server {}
+  (fn [{:keys [:partner/reqs :id/counter ::companies] :as db}]
+    ;; If all companies have an `:id` already, we are finished.
+    (if (every? (comp :id val) companies)
+      (r/done db)
+      (when-let [company-name (first reqs)]
+        (-> db
+            (update :partner/reqs set/difference #{company-name})
+            (update :webhook/reqs conj [company-name counter])
+            (update :partner/history conj [company-name counter])
+            (update :id/counter inc))))))
+
+(r/defproc webhook {:procs #{:w1}
+                    :local {:pc :webhook/handle-request}}
+  {:webhook/handle-request
+   (fn [{:keys [:webhook/reqs ::companies] :as db}]
+     ;; If all companies have an `:id` already, we are finished.
+     (if (every? (comp :id val) companies)
+       (r/done db)
+       ;; With the usage of `when-let` here, the value could be `nil`,
+       ;; which means that no state will change.
+       (when-let [[company-name id :as req] (first reqs)]
+         (let [{companies' ::companies :as new-db}
+               (-> db
+                   (update :webhook/reqs set/difference #{req})
+                   (assoc-in [::companies company-name :id] id))]
+           (-> new-db
+               ;; Note that `:loaded-companies` is a local variable (unamespaced
+               ;; keyword), so it will be available for the process which created
+               ;; it (some of the keywords in `:procs`).
+               ;; We are simulating here a load from a real database (using
+               ;; possible stale data) which will be used in other steps of
+               ;; this process.
+               (assoc :loaded-companies companies')
+               (r/goto :webhook/send-to-partner))))))
+
+   :webhook/send-to-partner
+   (fn [{:keys [:loaded-companies] :as db}]
+     ;; Companies are ready to be sent when all of its children have
+     ;; an `:id`.
+     (let [companies-ready (->> loaded-companies
+                                ;; If it has an `:id`, it was already sent,
+                                ;; so we ignore them.
+                                (remove (comp :id val))
+                                (filter (fn [[_ {:keys [:children]}]]
+                                          (every? #(-> loaded-companies % :id) children)))
+                                keys
+                                set)]
+       (-> db
+           (update :partner/reqs set/union companies-ready)
+           (r/goto :webhook/handle-request))))})
+
+;; We don't want the same company being sent twice to the partner server.
+(r/definvariant no-partner-history-duplicates
+  (fn [{:keys [:partner/history]}]
+    (= (->> history (map first) distinct count)
+       (count history))))
+
+(comment
+
+  ;; You can ask to generate a trace example (if a violation occurs, we will
+  ;; return the violation as we normally do, the trace eaxample only happens
+  ;; if every check was ok).
+  (def result
+    ;; No duplicates violation.
+    (r/run-model global
+                 #{initial-request partner-server
+                   webhook no-partner-history-duplicates}
+                 {:trace-example? true}))
+
+  (ra/visualize-result result)
+  (-> result
+      r/print-timeline-diff)
+
+  ;; TODO for implementation:
+  ;; - [x] Start implementation.
+  ;; - [x] Add database (Postgres).
+  ;; - [ ] Daycare center communication is through an HTTP request.
+
+  ())

--- a/test/example/partner_2.clj
+++ b/test/example/partner_2.clj
@@ -1,0 +1,172 @@
+(ns example.partner-2
+  (:require
+   [clojure.set :as set]
+   [medley.core :as medley]
+   [recife.anim :as ra]
+   [recife.core :as r]))
+
+(def global
+  {::companies {:c1 {:children #{:c2 :c4}}
+                :c2 {}
+                :c3 {:children #{:c1}}
+                :c4 {}}
+   :partner/reqs #{}
+   :webhook/reqs #{}
+   :id/counter 0
+   :partner/history []})
+
+;; We are now testing a temporal property (see `defproperty` below),
+;; which means that "something good will eventually occur" (https://en.wikipedia.org/wiki/Liveness#:~:text=Liveness%20guarantees%20are%20important%20properties,something%20bad%20does%20not%20occur%22.).
+
+;; Each process of `Recife` can stutter (see https://learntla.com/temporal-logic/termination/),
+;; the process will not run (or not run anymore) and it will be stopped (in
+;; stuttering state). A real process can fail (data center dies, server is thrown
+;; into the water etc) and so a process like `initial-request` can just stop
+;; and you can't do anything about it and the "something good" will not eventually
+;; occur, too bad.
+
+;; But here we are assuming that this does not happen (if it happens in the real
+;; world, then we probably will have bigger issues) and that the world is fair
+;; enough that it will at least retry the request at some point in time. So we
+;; can use the `:fair` keyword (here as a metadata of `initial-request`) to indicate
+;; that to our process. There is also `:fair+`, but it's not widely used, learn
+;; more about this in this great Hillel's article https://www.hillelwayne.com/post/fairness/.
+(r/defproc ^:fair initial-request {}
+  (fn [{:keys [::companies] :as db}]
+    (let [companies-with-no-children (->> companies
+                                          (medley/remove-vals (comp seq :children))
+                                          ;; Add a flag indicating that the company was already sent so
+                                          ;; we can get rid of the duplication violations.
+                                          (medley/map-vals #(assoc % :sent? true)))]
+      (-> db
+          (update :partner/reqs set/union (->> companies-with-no-children keys set))
+          (update ::companies merge companies-with-no-children)
+          (r/done)))))
+
+;; We add fairness here too.
+;; We add one more process here (`:p2`).
+(r/defproc ^:fair partner-server {:procs #{:p1 :p2}
+                                  :local {:pc :partner/server}}
+  ;; For step with non deterministic choice, see comment at
+  ;; `:webhook/send-to-partner` and then come back here.
+  ;; Here we are using the value of the global variable `partner/reqs`
+  ;; as our source of non-determinism.
+  {[:partner/server
+    {:req :partner/reqs}]
+   (fn [{:keys [:req :id/counter ::companies] :as db}]
+     (if (every? (comp :id val) companies)
+       (r/done db)
+       (when-let [company-name req]
+         (-> db
+             (update :partner/reqs set/difference #{company-name})
+             (update :webhook/reqs conj [company-name counter])
+             (update :partner/history conj [company-name counter])
+             (update :id/counter inc)))))})
+
+;; We add fairness here as well.
+;; We add one more process here (`:w2`).
+(r/defproc ^:fair webhook {:procs #{:w1 :w2}
+                           :local {:pc :webhook/handle-request}}
+  ;; Here we are using another way to pass the step, now with non determinism.
+  ;; We fetch one request (not all of them) non deterministically, adding
+  ;; a `:req` key to the main step function.
+  ;; Note that we are using a two-sized vector here with the name of the
+  ;; step as our key.
+  {[:webhook/handle-request
+    {:req :webhook/reqs}]
+   (fn [{:keys [:req ::companies] :as db}]
+     (if (every? (comp :id val) companies)
+       (r/done db)
+       (when-let [[company-name id] req]
+         (-> db
+             (update :webhook/reqs set/difference #{req})
+             (assoc-in [::companies company-name :id] id)
+             (r/goto :webhook/load-companies)))))
+
+   ;; This is emulating a query made to the database, where the view can be
+   ;; outdated in comparison with the stored data.
+   :webhook/load-companies
+   (fn [{:keys [::companies :global/locked?] :as db}]
+     (when-not locked?
+       (-> db
+           (assoc :loaded-companies companies)
+           ;; Use a global lock so we don't send duplicate history.
+           (assoc :global/locked? true)
+           (r/goto :webhook/send-to-partner))))
+
+   :webhook/send-to-partner
+   (fn [{:keys [:loaded-companies] :as db}]
+     (let [companies-ready (->> loaded-companies
+                                ;; Remove sent companies.
+                                (medley/remove-vals :sent?)
+                                (medley/remove-vals :id)
+                                (medley/filter-vals (fn [{:keys [:children]}]
+                                                      ;; We already sent companies with no children
+                                                      ;; in our initial request.
+                                                      (and children
+                                                           (every? #(-> loaded-companies % :id) children))))
+                                keys
+                                set)]
+       (if (empty? companies-ready)
+         (-> db
+             (assoc :global/locked? false)
+             (r/goto :webhook/handle-request))
+         (-> db
+             ;; Indicate that these companies were sent.
+             (update ::companies medley/deep-merge (->> companies-ready
+                                                        (mapv #(vector % {:sent? true}))
+                                                        (into {})))
+             (update :partner/reqs set/union companies-ready)
+             (assoc :global/locked? false)
+             (r/goto :webhook/handle-request)))))})
+
+(r/definvariant no-partner-history-duplicates
+  (fn [{:keys [:partner/history]}]
+    (= (->> history (map first) distinct count)
+       (count history))))
+
+;; All companies will have an `:id` in the end of everything.
+;; We say that at some point in time (`:eventually`) and forever
+;; (`always`) the companies will have an id (which is our main goal).
+(r/defproperty all-companies-will-have-an-id
+  [:eventually
+   [:always
+    (fn [{:keys [::companies]}]
+      (and (->> (vals companies)
+                (every? :id))
+           ;; Also check that the ids are in the correct order.
+           (> (-> companies :c3 :id)
+              (-> companies :c1 :id)
+              (-> companies :c4 :id))
+           (> (-> companies :c1 :id)
+              (-> companies :c2 :id))))]])
+
+(comment
+
+  (def result
+    (r/run-model global
+                 #{initial-request partner-server
+                   webhook no-partner-history-duplicates
+                   all-companies-will-have-an-id}
+                 {:trace-example? true}))
+
+  ;; With these functions you can see the timeline diff (`:-` or `:+`) to see
+  ;; what changed. `r/print-timeline-diff` prints the output to the STDOUT (REPL)
+  ;; and highlights the differences, so it may be easier to debug larger traces
+  ;; with it.
+  (r/timeline-diff result)
+  (r/print-timeline-diff result)
+
+  (ra/visualize-result result)
+
+  ;; TODO:
+  ;; - [x] IMPORTANT! When a temporal property is added, the successor in the
+  ;;       states file is not correct.
+  ;; - [x] Add invariants.
+  ;; - [x] Add temporal properties.
+  ;; - [x] Add two partner and two webhook processes.
+
+  ;; TODO for implementation:
+  ;; - [ ] Implementation.
+
+  ())

--- a/test/hillel/ch2_recycler_2.clj
+++ b/test/hillel/ch2_recycler_2.clj
@@ -38,3 +38,9 @@
   (fn [db]
     (and (>= (:trash/capacity db) 0)
          (>= (:recycle/capacity db) 0))))
+
+(comment
+
+  (r/run-model global #{main invariant})
+
+  ())

--- a/test/hillel/ch5_cache_1.clj
+++ b/test/hillel/ch5_cache_1.clj
@@ -28,6 +28,13 @@
 (comment
 
   ;; ok.
-  (r/run-model global #{actor time' invariant} #_{:raw-output? true})
+  (def states
+    (-> (r/run-model global #{actor time' invariant} {:dump-states? true})
+        r/states-from-result))
+  ;; `:dump-states?` creates a file with states and ranks (the level where a
+  ;; state appears first). It adds `:recife/transit-states-file-path` to the
+  ;; result of `run-model`, it's a implementation details that it's transit.
+
+  (r/random-traces-from-states states)
 
   ())

--- a/test/hillel/ch5_cache_4.clj
+++ b/test/hillel/ch5_cache_4.clj
@@ -43,6 +43,10 @@
 (comment
 
   ;; ok.
-  (r/run-model global #{actor time' invariant})
+  (def states
+    (-> (r/run-model global #{actor time' invariant} {:dump-states? true})
+        r/states-from-result))
+
+  (r/random-traces-from-states states 3)
 
   ())

--- a/test/hillel_test.clj
+++ b/test/hillel_test.clj
@@ -127,140 +127,16 @@
 
 (deftest ch2-recycler-1-test
   (let [result (r/run-model ch2-recycler-1/global
-                            #{ch2-recycler-1/main}
+                            #{ch2-recycler-1/main ch2-recycler-1/invariant}
                             default-options)]
     (testing "whole result"
-      (is (= {:trace
-              [[0
-                {:recife.core/procs {:x {:pc :hillel.ch2-recycler-1/main}}
-                 :trash/capacity 10
-                 :trash/bin #{}
-                 :recycle/capacity 10
-                 :recycle/bin #{}
-                 :hillel.ch2-recycler-1/items
-                 [{:type :recycle :size 5}
-                  {:type :trash :size 5}
-                  {:type :recycle :size 4}
-                  {:type :recycle :size 3}]}]
-               [1
-                {:recife.core/procs {:x {:pc :hillel.ch2-recycler-1/main}}
-                 :trash/capacity 10
-                 :trash/bin #{}
-                 :recycle/capacity 5
-                 :recycle/bin #{{:type :recycle :size 5}}
-                 :hillel.ch2-recycler-1/items
-                 [{:type :trash :size 5}
-                  {:type :recycle :size 4}
-                  {:type :recycle :size 3}]
-                 :recife/metadata
-                 {:context [:hillel.ch2-recycler-1/main {:self :x}]}}]
-               [2
-                {:recife.core/procs {:x {:pc :hillel.ch2-recycler-1/main}}
-                 :trash/capacity 5
-                 :trash/bin #{{:type :trash :size 5}}
-                 :recycle/capacity 5
-                 :recycle/bin #{{:type :recycle :size 5}}
-                 :hillel.ch2-recycler-1/items
-                 [{:type :recycle :size 4} {:type :recycle :size 3}]
-                 :recife/metadata
-                 {:context [:hillel.ch2-recycler-1/main {:self :x}]}}]
-               [3
-                {:recife.core/procs {:x {:pc :hillel.ch2-recycler-1/main}}
-                 :trash/capacity 5
-                 :trash/bin #{{:type :trash :size 5}}
-                 :recycle/capacity 1
-                 :recycle/bin
-                 #{{:type :recycle :size 5} {:type :recycle :size 4}}
-                 :hillel.ch2-recycler-1/items [{:type :recycle :size 3}]
-                 :recife/metadata
-                 {:context [:hillel.ch2-recycler-1/main {:self :x}]}}]
-               [4
-                {:recife.core/procs {:x {:pc :hillel.ch2-recycler-1/main}}
-                 :trash/capacity 2
-                 :trash/bin #{{:type :recycle :size 3} {:type :trash :size 5}}
-                 :recycle/capacity 1
-                 :recycle/bin
-                 #{{:type :recycle :size 5} {:type :recycle :size 4}}
-                 :hillel.ch2-recycler-1/items []
-                 :recife/metadata
-                 {:context [:hillel.ch2-recycler-1/main {:self :x}]}}]
-               [5
-                {:recife.core/procs {:x {:pc :recife.core/done}}
-                 :trash/capacity 2
-                 :trash/bin #{{:type :recycle :size 3} {:type :trash :size 5}}
-                 :recycle/capacity 1
-                 :recycle/bin
-                 #{{:type :recycle :size 5} {:type :recycle :size 4}}
-                 :hillel.ch2-recycler-1/items []
-                 :recife/metadata
-                 {:context [:hillel.ch2-recycler-1/main {:self :x}]}}]]
-              :trace-info {:trace-example? true}
+      (is (= {:trace :ok
+              :trace-info nil
               :distinct-states 6
-              :generated-states 6
+              :generated-states 7
               :seed 1
               :fp 0}
-             result))
-      (simulate-assert result))
-
-    (testing "timeline diff"
-      (is (= {:trace
-              [[0
-                {:recife.core/procs {:x {:pc :hillel.ch2-recycler-1/main}}
-                 :trash/capacity 10
-                 :trash/bin #{}
-                 :recycle/capacity 10
-                 :recycle/bin #{}
-                 :hillel.ch2-recycler-1/items
-                 [{:type :recycle :size 5}
-                  {:type :trash :size 5}
-                  {:type :recycle :size 4}
-                  {:type :recycle :size 3}]}]
-               [1
-                {:recycle/capacity {:- 10 :+ 5}
-                 :recycle/bin #{{:+ {:type :recycle :size 5}}}
-                 :hillel.ch2-recycler-1/items
-                 [{:- {:type :recycle :size 5}}
-                  {:type :trash :size 5}
-                  {:type :recycle :size 4}
-                  {:type :recycle :size 3}]
-                 {:+ :recife/metadata}
-                 {:context [:hillel.ch2-recycler-1/main {:self :x}]}}]
-               [2
-                {:trash/capacity {:- 10 :+ 5}
-                 :trash/bin #{{:+ {:type :trash :size 5}}}
-                 :hillel.ch2-recycler-1/items
-                 [{:- {:type :trash :size 5}}
-                  {:type :recycle :size 4}
-                  {:type :recycle :size 3}]}]
-               [3
-                {:recycle/capacity {:- 5 :+ 1}
-                 :recycle/bin
-                 #{{:+ {:type :recycle :size 4}} {:type :recycle :size 5}}
-                 :hillel.ch2-recycler-1/items
-                 [{:- {:type :recycle :size 4}} {:type :recycle :size 3}]}]
-               [4
-                {:trash/capacity {:- 5 :+ 2}
-                 :trash/bin
-                 #{{:+ {:type :recycle :size 3}} {:type :trash :size 5}}
-                 :hillel.ch2-recycler-1/items [{:- {:type :recycle :size 3}}]}]
-               [5
-                #:recife.core{:procs
-                              {:x
-                               {:pc
-                                {:- :hillel.ch2-recycler-1/main
-                                 :+ :recife.core/done}}}}]]
-              :trace-info {:trace-example? true}
-              :distinct-states 6
-              :generated-states 6
-              :seed 1
-              :fp 0}
-             (->> (r/timeline-diff result)
-                  (walk/prewalk (fn [form]
-                                  (cond
-                                    (instance? Mismatch form) {:+ (:+ form) :- (:- form)}
-                                    (instance? Deletion form) {:- (:- form)}
-                                    (instance? Insertion form) {:+ (:+ form)}
-                                    :else form)))))))))
+             result)))))
 
 (deftest ch2-recycler-2-test
   (is (= {:trace :ok
@@ -280,93 +156,191 @@
                               ch5-cache-3/invariant
                               ch5-cache-3/type-ok}
                             default-options)]
-    (is (= {:trace
-            [[0
-              {:recife.core/procs
-               {:a2
-                {:resources-needed 1
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/wait-for-resources}
-                :a1
-                {:resources-needed 1
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/wait-for-resources}
-                :time {:pc :hillel.ch5-cache-3/tick}}
-               :cache/resource-cap 1
-               :cache/resources-left 1}]
-             [1
-              {:recife.core/procs
-               {:a2
-                {:resources-needed 1
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/use-resources}
-                :a1
-                {:resources-needed 1
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/wait-for-resources}
-                :time {:pc :hillel.ch5-cache-3/tick}}
-               :cache/resource-cap 1
-               :cache/resources-left 1
-               :recife/metadata
-               {:context [:hillel.ch5-cache-3/wait-for-resources {:self :a2}]}}]
-             [2
-              {:recife.core/procs
-               {:a2
-                {:resources-needed 1
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/use-resources}
-                :a1
-                {:resources-needed 1
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/use-resources}
-                :time {:pc :hillel.ch5-cache-3/tick}}
-               :cache/resource-cap 1
-               :cache/resources-left 1
-               :recife/metadata
-               {:context [:hillel.ch5-cache-3/wait-for-resources {:self :a1}]}}]
-             [3
-              {:recife.core/procs
-               {:a2
-                {:resources-needed 0
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/use-resources}
-                :a1
-                {:resources-needed 1
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/use-resources}
-                :time {:pc :hillel.ch5-cache-3/tick}}
-               :cache/resource-cap 1
-               :cache/resources-left 0
-               :recife/metadata
-               {:context
-                [:hillel.ch5-cache-3/use-resources {:x 0 :self :a2}]}}]
-             [4
-              {:recife.core/procs
-               {:a2
-                {:resources-needed 0
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/use-resources}
-                :a1
-                {:resources-needed 0
-                 :ran? false
-                 :pc :hillel.ch5-cache-3/use-resources}
-                :time {:pc :hillel.ch5-cache-3/tick}}
-               :cache/resource-cap 1
-               :cache/resources-left -1
-               :recife/metadata
-               {:context
-                [:hillel.ch5-cache-3/use-resources {:x 0 :self :a1}]}}]]
-            :trace-info
-            {:violation
-             {:type :invariant
-              :name :hillel.ch5-cache-3/invariant
-              :data {:well [:this :is :it]}}}
-            :distinct-states 77
-            :generated-states 93
-            :seed 1
-            :fp 0}
-           result))
-    (simulate-assert result)))
+    (testing "trace result"
+      (is (= {:trace
+              [[0
+                {:recife.core/procs
+                 {:a2
+                  {:resources-needed 1
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/wait-for-resources}
+                  :a1
+                  {:resources-needed 1
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/wait-for-resources}
+                  :time {:pc :hillel.ch5-cache-3/tick}}
+                 :cache/resource-cap 1
+                 :cache/resources-left 1}]
+               [1
+                {:recife.core/procs
+                 {:a2
+                  {:resources-needed 1
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/use-resources}
+                  :a1
+                  {:resources-needed 1
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/wait-for-resources}
+                  :time {:pc :hillel.ch5-cache-3/tick}}
+                 :cache/resource-cap 1
+                 :cache/resources-left 1
+                 :recife/metadata
+                 {:context [:hillel.ch5-cache-3/wait-for-resources {:self :a2}]}}]
+               [2
+                {:recife.core/procs
+                 {:a2
+                  {:resources-needed 1
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/use-resources}
+                  :a1
+                  {:resources-needed 1
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/use-resources}
+                  :time {:pc :hillel.ch5-cache-3/tick}}
+                 :cache/resource-cap 1
+                 :cache/resources-left 1
+                 :recife/metadata
+                 {:context [:hillel.ch5-cache-3/wait-for-resources {:self :a1}]}}]
+               [3
+                {:recife.core/procs
+                 {:a2
+                  {:resources-needed 0
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/use-resources}
+                  :a1
+                  {:resources-needed 1
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/use-resources}
+                  :time {:pc :hillel.ch5-cache-3/tick}}
+                 :cache/resource-cap 1
+                 :cache/resources-left 0
+                 :recife/metadata
+                 {:context
+                  [:hillel.ch5-cache-3/use-resources {:x 0 :self :a2}]}}]
+               [4
+                {:recife.core/procs
+                 {:a2
+                  {:resources-needed 0
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/use-resources}
+                  :a1
+                  {:resources-needed 0
+                   :ran? false
+                   :pc :hillel.ch5-cache-3/use-resources}
+                  :time {:pc :hillel.ch5-cache-3/tick}}
+                 :cache/resource-cap 1
+                 :cache/resources-left -1
+                 :recife/metadata
+                 {:context
+                  [:hillel.ch5-cache-3/use-resources {:x 0 :self :a1}]}}]]
+              :trace-info
+              {:violation
+               {:type :invariant
+                :name :hillel.ch5-cache-3/invariant
+                :data {:well [:this :is :it]}}}
+              :distinct-states 77
+              :generated-states 93
+              :seed 1
+              :fp 0}
+             result))
+      (simulate-assert result))
+
+    (testing "timeline diff"
+      (is (= {:trace
+              [[0
+                {:recife.core/procs
+                 {:a2
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/wait-for-resources,
+                   :resources-needed 1},
+                  :a1
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/wait-for-resources,
+                   :resources-needed 1},
+                  :time {:pc :hillel.ch5-cache-3/tick}},
+                 :cache/resources-left 1,
+                 :cache/resource-cap 1}]
+               [1
+                {:recife.core/procs
+                 {:a2
+                  {:ran? false,
+                   :pc
+                   {:- :hillel.ch5-cache-3/wait-for-resources,
+                    :+ :hillel.ch5-cache-3/use-resources},
+                   :resources-needed 1},
+                  :a1
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/wait-for-resources,
+                   :resources-needed 1},
+                  :time {:pc :hillel.ch5-cache-3/tick}},
+                 {:+ :recife/metadata}
+                 {:context [:hillel.ch5-cache-3/wait-for-resources {:self :a2}]}}]
+               [2
+                {:recife.core/procs
+                 {:a2
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/use-resources,
+                   :resources-needed 1},
+                  :a1
+                  {:ran? false,
+                   :pc
+                   {:- :hillel.ch5-cache-3/wait-for-resources,
+                    :+ :hillel.ch5-cache-3/use-resources},
+                   :resources-needed 1},
+                  :time {:pc :hillel.ch5-cache-3/tick}},
+                 :recife/metadata
+                 {:context
+                  [:hillel.ch5-cache-3/wait-for-resources
+                   {:self {:- :a2, :+ :a1}}]}}]
+               [3
+                {:recife.core/procs
+                 {:a2
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/use-resources,
+                   :resources-needed {:- 1, :+ 0}},
+                  :a1
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/use-resources,
+                   :resources-needed 1},
+                  :time {:pc :hillel.ch5-cache-3/tick}},
+                 :cache/resources-left {:- 1, :+ 0},
+                 :recife/metadata
+                 {:context
+                  [{:- :hillel.ch5-cache-3/wait-for-resources,
+                    :+ :hillel.ch5-cache-3/use-resources}
+                   {:self {:- :a1, :+ :a2}, {:+ :x} 0}]}}]
+               [4
+                {:recife.core/procs
+                 {:a2
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/use-resources,
+                   :resources-needed 0},
+                  :a1
+                  {:ran? false,
+                   :pc :hillel.ch5-cache-3/use-resources,
+                   :resources-needed {:- 1, :+ 0}},
+                  :time {:pc :hillel.ch5-cache-3/tick}},
+                 :cache/resources-left {:- 0, :+ -1},
+                 :recife/metadata
+                 {:context
+                  [:hillel.ch5-cache-3/use-resources
+                   {:x 0, :self {:- :a2, :+ :a1}}]}}]],
+              :trace-info
+              {:violation
+               {:type :invariant,
+                :name :hillel.ch5-cache-3/invariant,
+                :data {:well [:this :is :it]}}},
+              :distinct-states 77,
+              :generated-states 93,
+              :seed 1,
+              :fp 0}
+             (->> (r/timeline-diff result)
+                  (walk/prewalk (fn [form]
+                                  (cond
+                                    (instance? Mismatch form) {:+ (:+ form) :- (:- form)}
+                                    (instance? Deletion form) {:- (:- form)}
+                                    (instance? Insertion form) {:+ (:+ form)}
+                                    :else form)))))))))
 
 (deftest ch5-server-3-test
   (let [result (r/run-model ch5-server-3/global


### PR DESCRIPTION
- Adds analyzer ns;
- Adds trace file;
- Adds support to use a function for non-determinism;
- Adds option to save trace to a file (using `StateWriter`);
- Adds function to read states from a result;
- Adds function to get random traces from saved states file;
- Adds internal `opts.edn` so we are able to pass parameters to the
  TLC handler in another JVM;
- Make `defproc` accept a simple function, map is not required, but it
  creates only one proc;
- Adds examples using the analyzer.

