### PR TITLE
Add defchecker, provenance example and check which temporal properties are violated

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -9,6 +9,7 @@
            recife.helpers/defproperty clojure.core/defn
            recife.helpers/deffairness clojure.core/defn
            recife.helpers/definvariant clojure.core/defn
+           recife.helpers/defchecker clojure.core/defn
            recife.helpers/defconstraint clojure.core/defn
            recife.helpers/defaction-constraint clojure.core/defn
            recife.helpers/defaction-property clojure.core/defn

--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,8 @@
                      clj-http-fake/clj-http-fake {:mvn/version "1.0.3"}
                      com.github.seancorfield/honeysql {:mvn/version "2.0.0-rc5"}
                      metosin/muuntaja {:mvn/version "0.6.8"}
-                     io.github.pfeodrippe/dev-tooling {:mvn/version "1.0.48"}}
+                     io.github.pfeodrippe/dev-tooling {:mvn/version "1.0.48"}
+                     org.clojure/core.logic {:mvn/version "1.0.1"}}
         :extra-paths ["test" "notebooks"]}
   :test {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
          :extra-deps {nubank/matcher-combinators {:mvn/version "3.1.4"}
@@ -43,7 +44,8 @@
                       clj-http-fake/clj-http-fake {:mvn/version "1.0.3"}
                       com.github.seancorfield/honeysql {:mvn/version "2.0.0-rc5"}
                       metosin/muuntaja {:mvn/version "0.6.8"}
-                      io.github.pfeodrippe/dev-tooling {:mvn/version "1.0.47"}}
+                      io.github.pfeodrippe/dev-tooling {:mvn/version "1.0.47"}
+                      org.clojure/core.logic {:mvn/version "1.0.1"}}
          :extra-paths ["test"]
          :main-opts   ["-m" "kaocha.runner"]}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -55,7 +55,7 @@
   lambdaisland/deep-diff2 {:mvn/version "2.0.108"}
   pfeodrippe/tla-edn {:mvn/version "0.14.0"}
   alandipert/interpol8 {:mvn/version "0.0.3"}
-  metosin/malli {:mvn/version "0.5.1"}
+  metosin/malli {:mvn/version "0.10.1"}
   quil/quil {:mvn/version "3.1.0"}
   com.cognitect/transit-clj {:mvn/version "1.0.324"}
   pfeodrippe/arrudeia {:mvn/version "0.11.0-SNAPSHOT"}

--- a/notebooks/recife/notebook/index.clj
+++ b/notebooks/recife/notebook/index.clj
@@ -64,5 +64,8 @@
   ;; - [ ] simulation
   ;; - [ ] model check
   ;; - [ ] non determinism
+  ;; - [ ] partner example
+  ;;   - [ ] driving implementation from traces
+  ;;   - [ ] reproducing bugs
 
   ())

--- a/notebooks/recife/notebook/index.clj
+++ b/notebooks/recife/notebook/index.clj
@@ -47,25 +47,32 @@
   ;; TODO:
   ;; - [x] Use `dev-tooling`
   ;; - [x[ Serve docs using GH pages
-  ;; - [x] reasoning
-  ;; - [x] fix responsiveness
-  ;; - [ ] proc
-  ;; - [ ] invariant
-  ;; - [ ] temporal property
-  ;; - [ ] fix flickering on phone
-  ;; - [ ] action property
-  ;; - [ ] constraint
-  ;; - [ ] action constraint
-  ;; - [ ] tutorial
-  ;; - [ ] design
-  ;;   - [ ] implementation details
-  ;; - [ ] gather data for statistics
-  ;; - [ ] generate
-  ;; - [ ] simulation
-  ;; - [ ] model check
-  ;; - [ ] non determinism
-  ;; - [ ] partner example
-  ;;   - [ ] driving implementation from traces
-  ;;   - [ ] reproducing bugs
+  ;; - [x] Reasoning
+  ;; - [x] Fix responsiveness
+  ;; - [ ] Proc
+  ;; - [ ] Invariant
+  ;; - [ ] Temporal property
+  ;; - [ ] Action property
+  ;; - [ ] Constraint
+  ;; - [ ] Action constraint
+  ;; - [ ] Tutorial
+  ;; - [ ] Design
+  ;;   - [ ] Implementation details
+  ;; - [ ] Gather data for statistics
+  ;; - [ ] Generate
+  ;; - [ ] Simulation
+  ;; - [ ] Model checking
+  ;; - [ ] Non determinism
+  ;; - [ ] Partner example
+  ;;   - [ ] Driving implementation from traces
+  ;;   - [ ] Reproducing bugs
+
+  ;; TODO:
+  ;; - [ ] Fix flickering on phone
+  ;;   -  [ ] Try to use the unbundled version of Clerk
+  ;; - [ ] Add search field
+  ;; - [ ] Add ToC
+  ;; - [ ] Add navigation between pages
+  ;; - [ ] Diminish font size for mobile
 
   ())

--- a/src/recife/core.clj
+++ b/src/recife/core.clj
@@ -1816,8 +1816,7 @@ VIEW
                                                trace-example? dump-states?]
                                         :as opts
                                         :or {workers :auto
-                                             async true
-                                             use-buffer true}}]
+                                             async true}}]
    ;; Do some validation.
    (some->> (m/explain schema/Operator next-operator)
             me/humanize
@@ -1854,7 +1853,7 @@ VIEW
          _ (when use-buffer
              (r.buf/reset-buf!)
              (r.buf/sync!) ; sync so we can make sure that the writer can write
-             (reset! r.buf/*contents [])
+             (reset! r.buf/*contents {})
              (r.buf/start-sync-loop!))
          ;; Also put a file with opts in the same folder so we can read configuration
          ;; in the tlc-handler function.
@@ -2214,7 +2213,8 @@ VIEW
   "Save data that can be fetched in real time, it can be used for statistics."
   r.buf/save!)
 
-(def read-saved-data
+(def ^{:arglists (:arglists (meta #'r.buf/read-contents))}
+  read-saved-data
   "Read saved data, see `save!`."
   r.buf/read-contents)
 

--- a/src/recife/core.clj
+++ b/src/recife/core.clj
@@ -2292,6 +2292,7 @@ VIEW
   ;; - [ ] Integrate with Soufflé (https://souffle-lang.github.io/source)?
   ;; - [ ] Warn about invalid temporal property?
   ;; - [ ] Add `["-lncheck" "final"]` by default
+  ;; - [ ] Check if it's possible to do refinement
 
   ())
 

--- a/src/recife/helpers.clj
+++ b/src/recife/helpers.clj
@@ -5,7 +5,6 @@
    [tla-edn-2.core :as tla-edn])
   (:import
    (tlc2 TLCGlobals)
-   (tlc2.tool.impl Tool)
    (tlc2.util IdThread)
    (recife RecifeEdnValue)))
 
@@ -13,285 +12,7 @@
 (set! *unchecked-math* false)
 #_(set! *unchecked-math* :warn-on-boxed)
 
-(def ^:dynamic *env* {:global-vars [] :local-vars []})
-
-(defn- add-global-vars
-  [vs]
-  (update *env* :global-vars
-          #(apply conj % vs)))
-
-(defn- add-local-vars
-  [vs]
-  (update *env* :local-vars
-          #(apply conj % vs)))
-
-(defn- invoke
-  [form]
-  (let [local-vars (->> (:local-vars *env*)
-                        (mapv (fn [l]
-                                (if (seq? l)
-                                  (last l)
-                                  l))))
-        global-vars (->> (:global-vars *env*)
-                         (mapv (fn [l]
-                                 (if (seq? l)
-                                   (last l)
-                                   l))))]
-    (if (or (::raw-form (meta form))
-            (and (seq? form)
-                 (not (keyword? (first form)))
-                 (resolve (first form))
-                 (or (::operator? (meta (resolve (first form))))
-                     (= (namespace (symbol (resolve (first form)))) "recife.helpers"))))
-      form
-      (if (= (count global-vars) 2)
-        `[:invoke (quote ~(->> local-vars
-                               (mapv (fn [l] [(keyword l) l]))
-                               (into {})))
-          (fn [{:keys ~(vec local-vars)
-                :as db#}
-               db'#]
-            (let [~(first global-vars) db#
-                  ~(second global-vars) db'#
-                  ~'--db db#
-                  ~'--db' db'#]
-              ~form))]
-        `[:invoke (quote ~(->> local-vars
-                               (mapv (fn [l] [(keyword l) l]))
-                               (into {})))
-          (fn [{:keys ~(vec local-vars)
-                :as db#}]
-            (let [~(first global-vars) db#]
-              ~form))]))))
-
-(defn- parse-decl
-  [decl]
-  (if (or (= (count decl) 2)
-          (and (> (count decl) 2)
-               (not (string? (first decl)))))
-    [nil (first decl) (drop 1 decl)]
-    [(first decl) (second decl) (drop 2 decl)]))
-
-(declare get-trace-value)
-(declare set-trace-value!)
-
-(defmacro defproperty
-  {:arglists '([name doc-string? [db] body])}
-  [name & decl]
-  (let [[_doc-string params body] (parse-decl decl)]
-    `(r/defproperty ~name
-       (binding [*env* (quote ~(add-global-vars
-                                (mapv (fn [p#] `(quote ~p#))
-                                      params)))]
-         (eval '~@body)))))
-
-(defn -save-action-property-violation
-  [name db']
-  (when (not (get-trace-value :recife/trace-violated?))
-    (let [current-state (tlc2.util.IdThread/getCurrentState)]
-      (r/save! :recife/violation
-               {:trace (->> (conj (->> (tlc2.module.TLCExt/getTrace nil nil nil
-                                                                    current-state
-                                                                    nil 0 nil)
-                                       tla-edn-2.core/to-edn
-                                       (mapv :main-var))
-                                  ;; Append next state to trace.
-                                  db')
-                            (map-indexed (fn [idx step] [idx step]))
-                            vec)
-                :type :action-property
-                :name name})
-      (set-trace-value! :recive/trace-violated? true)))
-  false)
-
-(defmacro defaction-property
-  {:arglists '([name doc-string? [db db'] body])}
-  [name & decl]
-  (let [[_doc-string params body] (parse-decl decl)
-        _ (when-not (= (count params) 2)
-            (throw (ex-info "Action constraints requires two arguments"
-                            {:params params
-                             :expected '[db db']})))
-        body (list (cons `box (list (list 'or (cons 'do body)
-                                          `(-save-action-property-violation
-                                            (symbol ~(str *ns*) (str '~name))
-                                            ~'--db')))))]
-    `(r/defaction-property ~name
-       (binding [*env* (quote ~(add-global-vars
-                                (mapv (fn [p#] `(quote ~p#))
-                                      params)))]
-         (eval '~@body)))))
-
-(defn -save-invariant-violation
-  [name]
-  (when (not (get-trace-value :recife/trace-violated?))
-    (let [current-state (tlc2.util.IdThread/getCurrentState)]
-      (r/save! :recife/violation
-               {:trace (->> (->> (tlc2.module.TLCExt/getTrace nil nil nil
-                                                              current-state
-                                                              nil 0 nil)
-                                 tla-edn-2.core/to-edn
-                                 (mapv :main-var))
-                            (map-indexed (fn [idx step] [idx step]))
-                            vec)
-                :type :invariant
-                :name name})
-      (set-trace-value! :recive/trace-violated? true)))
-  false)
-
-(defmacro definvariant
-  {:arglists '([name doc-string? [db] body])}
-  [name & decl]
-  (let [[doc-string params body] (parse-decl decl)]
-    `(r/definvariant ~name
-       ~doc-string
-       (fn ~params
-         (or ~@body
-             (-save-invariant-violation (symbol ~(str *ns*) (str '~name))))))))
-
-(defmacro deffairness
-  {:arglists '([name doc-string? [db] body])}
-  [name & decl]
-  (let [[_doc-string params body] (parse-decl decl)]
-    `(r/deffairness ~name
-       (binding [*env* (quote ~(add-global-vars
-                                (mapv (fn [p#] `(quote ~p#))
-                                      params)))]
-         (eval '~@body)))))
-
-(defmacro defconstraint
-  {:arglists '([name doc-string? [db] body])}
-  [name & decl]
-  (let [[_doc-string params body] (parse-decl decl)]
-    `(r/defconstraint ~name
-       (fn ~params
-         ~@body))))
-
-(defmacro defaction-constraint
-  {:arglists '([name doc-string? [db db'] body])}
-  [name & decl]
-  (let [[_doc-string params body] (parse-decl decl)]
-    (when-not (= (count params) 2)
-      (throw (ex-info "Action constraints requires two arguments"
-                      {:params params
-                       :expected '[db db']})))
-    `(r/defaction-constraint ~name
-       (fn ~params
-         ~@body))))
-
-(defn- for-all*
-  [bindings body]
-  (let [actual-bindings {`'~(first bindings) (second bindings)}]
-    `(binding [*env* (quote ~(add-local-vars (keys actual-bindings)))]
-       (eval '[:for-all ~actual-bindings
-               ~(binding [*env* (add-local-vars (keys actual-bindings))]
-                  (if (> (count bindings) 2)
-                    (for-all* (drop 2 bindings) body)
-                    `(do ~(invoke body))))]))))
-
-(defmacro for-all
-  [bindings body]
-  (for-all* bindings body))
-
-(defn- for-some*
-  [bindings body]
-  (let [actual-bindings {`'~(first bindings) (second bindings)}]
-    `(binding [*env* (quote ~(add-local-vars (keys actual-bindings)))]
-       (eval '[:exists ~actual-bindings
-               ~(binding [*env* (add-local-vars (keys actual-bindings))]
-                  (if (> (count bindings) 2)
-                    (for-some* (drop 2 bindings) body)
-                    `(do ~(invoke body))))]))))
-
-(defmacro for-some
-  [bindings body]
-  (for-some* bindings body))
-
-(defmacro leads-to
-  [source target]
-  `[:leads-to
-    ~(invoke source)
-    ~(invoke target)])
-
-(defmacro always
-  [body]
-  `[:always
-    ~(invoke body)])
-
-(defmacro eventually
-  [body]
-  `[:eventually
-    ~(invoke body)])
-
-(defmacro box
-  [body]
-  `[:box
-    ~(invoke body)])
-
-(defmacro fair
-  [body]
-  `[:fair
-    ~(invoke body)])
-
-(defmacro fair+
-  [body]
-  `[:fair+
-    ~(invoke body)])
-
-(defmacro and*
-  [& body]
-  `[:and ~@(mapv invoke body)])
-
-(defmacro or*
-  [& body]
-  `[:or ~@(mapv invoke body)])
-
-(defmacro call
-  "Invoke process step."
-  [proc body]
-  (let [proc' (eval proc)]
-    (when-not (= (type proc') ::r/Proc)
-      (throw (ex-info "First argument of `call` should be a proc (return of `recife.core/defproc`)"
-                      {:non-proc proc})))
-    (into [:or]
-          (for [step-key (:steps-keys proc')]
-            `(for-all [~'self (keys (:procs ~proc))]
-               ^::raw-form
-               [:call ~step-key '~'self
-                ~(invoke body)])))))
-
-(defn combine
-  "Get all the possible combinations of the domain with the values.
-
-  See https://www.learntla.com/core/functions.html#function-sets and
-  `-maps` at https://github.com/Viasat/salt#maps.
-
-  Returns a lazy value so things don't get stuck when the combination
-  has many elements, values are randomized."
-  [domain values]
-  #_(def domain domain)
-  #_(def values values)
-  (let [domain->pairs (->> (for [a (shuffle (set domain))
-                                 b (shuffle (set values))]
-                             [a b])
-                           (group-by first)
-                           (into [])
-                           shuffle)
-        #_ #__ (def domain->pairs domain->pairs)
-        domain-seq? (when (every? number? domain)
-                      (let [domain-max (apply max domain)
-                            domain-range (range (inc domain-max))]
-                        (= (set domain-range)
-                           (set domain))))]
-    #_(def aaa (apply comb/cartesian-product (vals domain->pairs)))
-    (->> (apply comb/cartesian-product (vals domain->pairs))
-         (map #(if domain-seq?
-                 (mapv last (sort-by first %))
-                 (into {} %))))))
-
-#_(take 10 (combine #{:a :b :c :d :e}
-                    #{10 20 }))
-
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Trace
 (defn get-level
   "Get current TLC level (depth in a trace)."
   []
@@ -345,6 +66,338 @@
                 (.getLocalValue TLCGlobals/simulator id))
               tla-edn/to-edn))))
 
+;;;;;;;;;;;;;;;;;;;;;; Helper functions for operators
+(def ^:dynamic *env* {:global-vars [] :local-vars []})
+
+(defn- add-global-vars
+  [vs]
+  (update *env* :global-vars
+          #(apply conj % vs)))
+
+(defn- add-local-vars
+  [vs]
+  (update *env* :local-vars
+          #(apply conj % vs)))
+
+(defn- invoke
+  [form]
+  (let [local-vars (->> (:local-vars *env*)
+                        (mapv (fn [l]
+                                (if (seq? l)
+                                  (last l)
+                                  l))))
+        global-vars (->> (:global-vars *env*)
+                         (mapv (fn [l]
+                                 (if (seq? l)
+                                   (last l)
+                                   l))))]
+    (if (or (::raw-form (meta form))
+            (and (seq? form)
+                 (not (keyword? (first form)))
+                 (resolve (first form))
+                 (or (::operator? (meta (resolve (first form))))
+                     (= (namespace (symbol (resolve (first form)))) "recife.helpers"))))
+      form
+      (if (= (count global-vars) 2)
+        `[:invoke (quote ~(->> local-vars
+                               (mapv (fn [l] [(keyword l) l]))
+                               (into {})))
+          (fn [{:keys ~(vec local-vars)
+                :as db#}
+               db'#]
+            (let [~(first global-vars) db#
+                  ~(second global-vars) db'#
+                  ~'--db db#
+                  ~'--db' db'#]
+              ~form))]
+        `[:invoke (quote ~(->> local-vars
+                               (mapv (fn [l] [(keyword l) l]))
+                               (into {})))
+          (fn [{:keys ~(vec local-vars)
+                :as db#}]
+            (let [~(first global-vars) db#]
+              ~form))]))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Quantifiers and functions
+(defn- for-all*
+  [bindings body]
+  (let [actual-bindings {`'~(first bindings) (second bindings)}]
+    `(binding [*env* (quote ~(add-local-vars (keys actual-bindings)))]
+       (eval '[:for-all ~actual-bindings
+               ~(binding [*env* (add-local-vars (keys actual-bindings))]
+                  (if (> (count bindings) 2)
+                    (for-all* (drop 2 bindings) body)
+                    `(do ~(invoke body))))]))))
+
+(defmacro for-all
+  [bindings body]
+  (for-all* bindings body))
+
+(defn- for-some*
+  [bindings body]
+  (let [actual-bindings {`'~(first bindings) (second bindings)}]
+    `(binding [*env* (quote ~(add-local-vars (keys actual-bindings)))]
+       (eval '[:exists ~actual-bindings
+               ~(binding [*env* (add-local-vars (keys actual-bindings))]
+                  (if (> (count bindings) 2)
+                    (for-some* (drop 2 bindings) body)
+                    `(do ~(invoke body))))]))))
+
+(defmacro for-some
+  [bindings body]
+  (for-some* bindings body))
+
+(defmacro leads-to
+  [source target]
+  `[:leads-to
+    ~(invoke source)
+    ~(invoke target)])
+
+(defmacro implies*
+  "Note that this `implies` works in the TLA+ level, it should be used only
+  in temporal properties."
+  [source target]
+  `[:implies
+    ~(invoke source)
+    ~(invoke target)])
+
+(defmacro always
+  [body]
+  `[:always
+    ~(invoke body)])
+
+(defmacro eventually
+  [body]
+  `[:eventually
+    ~(invoke body)])
+
+(defmacro box
+  [body]
+  `[:box
+    ~(invoke body)])
+
+(defmacro fair
+  [body]
+  `[:fair
+    ~(invoke body)])
+
+(defmacro fair+
+  [body]
+  `[:fair+
+    ~(invoke body)])
+
+(defmacro and*
+  [& body]
+  `[:and ~@(mapv invoke body)])
+
+(defmacro or*
+  [& body]
+  `[:or ~@(mapv invoke body)])
+
+(defmacro not*
+  [body]
+  `[:not ~body])
+
+(defmacro current-state
+  []
+  `[:current-state])
+
+(defmacro next-state
+  []
+  `[:next-state])
+
+(defmacro =*
+  [v1 v2]
+  `[:=
+    ~(invoke v1)
+    ~(invoke v2)])
+
+(defmacro call
+  "Invoke process step."
+  [proc body]
+  (let [proc' (eval proc)]
+    (when-not (= (type proc') ::r/Proc)
+      (throw (ex-info "First argument of `call` should be a proc (return of `recife.core/defproc`)"
+                      {:non-proc proc})))
+    (into [:or]
+          (for [step-key (:steps-keys proc')]
+            `(for-all [~'self (keys (:procs ~proc))]
+               ^::raw-form
+               [:call ~step-key '~'self
+                ~(invoke body)])))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Defs
+(defn- parse-decl
+  [decl]
+  (if (or (= (count decl) 2)
+          (and (> (count decl) 2)
+               (not (string? (first decl)))))
+    [nil (first decl) (drop 1 decl)]
+    [(first decl) (second decl) (drop 2 decl)]))
+
+(defn -save-temporal-property-violation
+  [name]
+  (when (not (get-trace-value :recife/trace-violated?))
+    (let [current-state (tlc2.util.IdThread/getCurrentState)]
+      (r/save! :recife/violation
+               {:trace (->> (->> (tlc2.module.TLCExt/getTrace nil nil nil
+                                                              current-state
+                                                              nil 0 nil)
+                                 tla-edn-2.core/to-edn
+                                 (mapv :main-var))
+                            (map-indexed (fn [idx step] [idx step]))
+                            vec)
+                :type :temporal-property
+                :name name})
+      (set-trace-value! :recive/trace-violated? true)))
+  false)
+
+(defmacro defproperty
+  {:arglists '([name doc-string? [db] body])}
+  [name & decl]
+  (let [[_doc-string params body] (parse-decl decl)
+        #_ #_body (list
+                   (concat
+                    (cons `or*
+                          body)
+                    (list `(boolean (println :aaaa)))
+                    #_(list (list 'eval (list '-save-temporal-property-violation
+                                              (list 'symbol (str *ns*)
+                                                    (str (quote name))))))))]
+    `(r/-defproperty ~name
+       (binding [*env* (quote ~(add-global-vars
+                                (mapv (fn [p#] `(quote ~p#))
+                                      params)))]
+         (eval '~@body)))))
+
+(defn -save-action-property-violation
+  [name db']
+  (when (not (get-trace-value :recife/trace-violated?))
+    (let [current-state (tlc2.util.IdThread/getCurrentState)]
+      (r/save! :recife/violation
+               {:trace (->> (conj (->> (tlc2.module.TLCExt/getTrace nil nil nil
+                                                                    current-state
+                                                                    nil 0 nil)
+                                       tla-edn-2.core/to-edn
+                                       (mapv :main-var))
+                                  ;; Append next state to trace.
+                                  db')
+                            (map-indexed (fn [idx step] [idx step]))
+                            vec)
+                :type :action-property
+                :name name})
+      (set-trace-value! :recive/trace-violated? true)))
+  false)
+
+(defmacro defaction-property
+  {:arglists '([name doc-string? [db db'] body])}
+  [name & decl]
+  (let [[_doc-string params body] (parse-decl decl)
+        _ (when-not (= (count params) 2)
+            (throw (ex-info "Action constraints requires two arguments"
+                            {:params params
+                             :expected '[db db']})))
+        body (list (cons `box (list (list 'or (cons 'do body)
+                                          `(-save-action-property-violation
+                                            (symbol ~(str *ns*) (str '~name))
+                                            ~'--db')))))]
+    `(r/-defaction-property ~name
+       (binding [*env* (quote ~(add-global-vars
+                                (mapv (fn [p#] `(quote ~p#))
+                                      params)))]
+         (eval '~@body)))))
+
+(defn -save-invariant-violation
+  [name]
+  (when (not (get-trace-value :recife/trace-violated?))
+    (let [current-state (tlc2.util.IdThread/getCurrentState)]
+      (r/save! :recife/violation
+               {:trace (->> (->> (tlc2.module.TLCExt/getTrace nil nil nil
+                                                              current-state
+                                                              nil 0 nil)
+                                 tla-edn-2.core/to-edn
+                                 (mapv :main-var))
+                            (map-indexed (fn [idx step] [idx step]))
+                            vec)
+                :type :invariant
+                :name name})
+      (set-trace-value! :recive/trace-violated? true)))
+  false)
+
+(defmacro definvariant
+  {:arglists '([name doc-string? [db] body])}
+  [name & decl]
+  (let [[doc-string params body] (parse-decl decl)]
+    `(r/-definvariant ~name
+       ~doc-string
+       (fn ~params
+         (or ~@body
+             (-save-invariant-violation (symbol ~(str *ns*) (str '~name))))))))
+
+(defmacro deffairness
+  {:arglists '([name doc-string? [db] body])}
+  [name & decl]
+  (let [[_doc-string params body] (parse-decl decl)]
+    `(r/-deffairness ~name
+       (binding [*env* (quote ~(add-global-vars
+                                (mapv (fn [p#] `(quote ~p#))
+                                      params)))]
+         (eval '~@body)))))
+
+(defmacro defconstraint
+  {:arglists '([name doc-string? [db] body])}
+  [name & decl]
+  (let [[_doc-string params body] (parse-decl decl)]
+    `(r/-defconstraint ~name
+       (fn ~params
+         ~@body))))
+
+(defmacro defaction-constraint
+  {:arglists '([name doc-string? [db db'] body])}
+  [name & decl]
+  (let [[_doc-string params body] (parse-decl decl)]
+    (when-not (= (count params) 2)
+      (throw (ex-info "Action constraints requires two arguments"
+                      {:params params
+                       :expected '[db db']})))
+    `(r/-defaction-constraint ~name
+       (fn ~params
+         ~@body))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Combine
+(defn combine
+  "Get all the possible combinations of the domain with the values.
+
+  See https://www.learntla.com/core/functions.html#function-sets and
+  `-maps` at https://github.com/Viasat/salt#maps.
+
+  Returns a lazy value so things don't get stuck when the combination
+  has many elements, values are randomized."
+  [domain values]
+  #_(def domain domain)
+  #_(def values values)
+  (let [domain->pairs (->> (for [a (shuffle (set domain))
+                                 b (shuffle (set values))]
+                             [a b])
+                           (group-by first)
+                           (into [])
+                           shuffle)
+        #_ #__ (def domain->pairs domain->pairs)
+        domain-seq? (when (every? number? domain)
+                      (let [domain-max (apply max domain)
+                            domain-range (range (inc domain-max))]
+                        (= (set domain-range)
+                           (set domain))))]
+    #_(def aaa (apply comb/cartesian-product (vals domain->pairs)))
+    (->> (apply comb/cartesian-product (vals domain->pairs))
+         (map #(if domain-seq?
+                 (mapv last (sort-by first %))
+                 (into {} %))))))
+
+#_(take 10 (combine #{:a :b :c :d :e}
+                    #{10 20 }))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Misc
 (defmacro with-features
   "Just some helper so feature flags are applied in compilation time.
 

--- a/src/recife/helpers.clj
+++ b/src/recife/helpers.clj
@@ -99,9 +99,11 @@
                      (= (namespace (symbol (resolve (first form)))) "recife.helpers"))))
       form
       (if (= (count global-vars) 2)
-        `[:invoke (quote ~(->> local-vars
-                               (mapv (fn [l] [(keyword l) l]))
-                               (into {})))
+        `[:invoke (with-meta
+                    (quote ~(->> local-vars
+                                 (mapv (fn [l] [(keyword l) l]))
+                                 (into {})))
+                    {:form ~(pr-str form)})
           (fn [{:keys ~(vec local-vars)
                 :as db#}
                db'#]
@@ -110,9 +112,11 @@
                   ~'--db db#
                   ~'--db' db'#]
               ~form))]
-        `[:invoke (quote ~(->> local-vars
-                               (mapv (fn [l] [(keyword l) l]))
-                               (into {})))
+        `[:invoke (with-meta
+                    (quote ~(->> local-vars
+                                 (mapv (fn [l] [(keyword l) l]))
+                                 (into {})))
+                    {:form ~(pr-str form)})
           (fn [{:keys ~(vec local-vars)
                 :as db#}]
             (let [~(first global-vars) db#]

--- a/src/recife/trace.clj
+++ b/src/recife/trace.clj
@@ -1,0 +1,233 @@
+(ns recife.trace
+  (:require
+   [malli.core :as m]
+   [recife.core :as r]))
+
+(defn temporal-property->map
+  [temporal-property]
+  {:type :root
+   :child (m/parse
+           [:schema {:registry
+                     {"tla"
+                      [:or
+                       [:catn
+                        [:type [:= :for-all]]
+                        [:bindings [:map-of :symbol [:schema [:ref "tla"]]]]
+                        [:child [:schema [:ref "tla"]]]]
+                       [:catn
+                        [:type [:= :leads-to]]
+                        [:source [:schema [:ref "tla"]]]
+                        [:target [:schema [:ref "tla"]]]]
+                       [:catn
+                        [:type [:= :invoke]]
+                        [:bindings [:map-of :keyword [:schema [:ref "tla"]]]]
+                        [:function [:schema [:ref "tla"]]]]
+                       [:catn
+                        [:type [:= :not]]
+                        [:child [:schema [:ref "tla"]]]]
+                       fn?
+                       coll?
+                       symbol?]}}
+            "tla"]
+           (:property temporal-property))})
+
+(defmulti parse-tla :type)
+
+(defmethod parse-tla :default
+  [value]
+  (throw (ex-info "Unknown tla identifier"
+                  {:identifier (:type value)
+                   :error :__NOT_IMPLEMENTED
+                   :value value})))
+
+(defmethod parse-tla :invoke
+  [{:keys [bindings function env]}]
+  `{:value (~function (merge (:db ~'trace) ~bindings))
+    :debug {:env ~env
+            :type :invoke}})
+
+(defmethod parse-tla :not
+  [{:keys [child env]}]
+  `(let [res# ~(parse-tla (assoc child :env env))]
+     {:value (not (:value res#))
+      :debug {:child res#
+              :env ~env
+              :type :not}}))
+
+(defmethod parse-tla :for-all
+  [{:keys [bindings child env]}]
+  `(let [result# (doall
+                  (for ~(->> bindings
+                             (apply concat)
+                             vec)
+                    ~(parse-tla (assoc child :env (merge env (->> (keys bindings)
+                                                                  (mapv (fn [sym]
+                                                                          [(keyword sym) sym]))
+                                                                  (into {})))))))]
+     {:value (mapv :value result#)
+      :debug {:children result#
+              :env ~env
+              :type :for-all}}))
+
+(defn -leads-to
+  [trace id env source-result target-result]
+  (let [key* {:id id
+              :env env
+              :type :leads-to}
+        last-state? (or (nil? (:next-idx trace))
+                        (<= (:next-idx trace)
+                            (:idx trace)))
+        source-value (:value source-result)
+        target-value (:value target-result)
+        history (get @(:tableau trace) key*)
+        was-enabled (:source-enabled (last history))
+        source-enabled (if target-value
+                         ;; Disable source when target is true.
+                         false
+                         (or source-value was-enabled))]
+    (swap! (:tableau trace) update key*
+           (comp vec conj)
+           {:idx (:idx trace)
+            :source-enabled (boolean source-enabled)
+            :target-enabled target-value})
+    ;; If we are not in last state, we don't know the result yet.
+    {:value (boolean
+             (or (not last-state?)
+                 (not source-enabled)
+                 ;; We need to iterate on the loopback (if any) to check
+                 ;; if target becomes eventually true.
+                 (when-let [next-idx (:next-idx trace)]
+                   (some :target-enabled (drop next-idx history)))))
+     :debug {:env env
+             :source-result source-result
+             :target-result target-result
+             :type :leads-to}}))
+
+(defmethod parse-tla :leads-to
+  [{:keys [source target env]}]
+  (let [id (keyword (gensym))]
+    `(-leads-to ~'trace ~id ~env
+                ~(parse-tla (assoc source :env env))
+                ~(parse-tla (assoc target :env env)))))
+
+#_(defmethod parse-tla :always
+  [{:keys [source target env]}]
+  (let [id (keyword (gensym))]
+    `(let [trace# ~'trace
+           k# {:id ~id
+               :env ~env
+               :type :leads-to}
+           last-state?# (or (nil? (:next-idx trace#))
+                            (<= (:next-idx trace#)
+                                (:idx trace#)))
+           source-result# ~(parse-tla (assoc source :env env))
+           target-result# ~(parse-tla (assoc target :env env))
+           source-value# (:value source-result#)
+           target-value# (:value target-result#)
+           history# (get @(:tableau trace#) k#)
+           was-enabled# (:source-enabled (last history#))
+           source-enabled# (if target-value#
+                             ;; Disable source when target is true.
+                             false
+                             (or source-value# was-enabled#))]
+       (swap! (:tableau trace#) update k#
+              (comp vec conj)
+              {:idx (:idx trace#)
+               :source-enabled (boolean source-enabled#)
+               :target-enabled target-value#})
+       ;; If we are not in last state, we don't know the result yet.
+       {:value (boolean
+                 (or (not last-state?#)
+                     (not source-enabled#)
+                     ;; We need to iterate on the loopback (if any) to check
+                     ;; if target becomes eventually true.
+                     (when-let [next-idx# (:next-idx trace#)]
+                       (some :target-enabled (drop next-idx# history#)))))
+        :debug {:env ~env
+                :source-result source-result#
+                :target-result target-result#
+                :type :leads-to}})))
+
+(defn -process-for-all
+  [result]
+  (let [values (flatten (:value result))]
+    {:value (every? true? values)
+     :debug {:type :root
+             :child result}}))
+
+;; :root knows how to deal with the different kinds of children so
+;; it can process a boolean result.
+(defmethod parse-tla :root
+  [{:keys [child]}]
+  `(let [result# ~(parse-tla child)]
+     (case ~(:type child)
+       :for-all (-process-for-all result#))))
+
+(defn check-temporal-property
+  "Given a result (the dereffed return from `r/run-model`), it checks if a
+  temporal property is violated by it.
+
+  It should be useful for discovering which temporal property broke an
+  assumption (as TLC does not give us this information by default).
+
+  We reconstruct clojure code from the Recife TLA+ representation (hiccup-like)
+  and try to emulate (as best as possible) the algorithm for checking a temporal
+  property using pure Clojure.
+
+  The return is a map with a `:violated?` key, indicating if this temp property
+  is violated by the trace from `result`."
+  [result temporal-property]
+  (def temporal-property temporal-property)
+  (let [compiled-property
+        (eval `(fn [~'trace]
+                 (let [~'trace (update ~'trace :tableau atom)]
+                   [~(parse-tla (temporal-property->map temporal-property))
+                    (deref (:tableau ~'trace))])))]
+    (loop [[[idx db] & trace-rest] (:trace result)
+           tableau {}
+           trace-result nil]
+      (let [trace {:idx idx
+                   :next-idx (if (seq trace-rest)
+                               (inc idx)
+                               (-> result :trace-info :violation :state-number))
+                   :db db
+                   :tableau tableau}]
+
+        (if idx
+          (let [[trace-result tableau] (compiled-property trace)]
+            (recur trace-rest
+                   tableau
+                   trace-result))
+          (with-meta {:violated? (not (:value trace-result))}
+            {:debug (:debug trace-result)
+             :tableau (:tableau trace)}))))))
+
+(defn check-temporal-properties
+  "Given a result (the dereffed return from `r/run-model`) and the temporal properties
+  (`components`, which is the same set that you pass to `r/run-model` in the second argument,
+  but we just care here about the temporal properties), it checks which temporal property
+  are violated.
+
+  Check `check-temporal-property` for more information about the return values."
+  [result components]
+  (let [properties (set (filter #(= (type %) ::r/Property)
+                                (flatten (seq components))))]
+    (->> properties
+         (mapv (fn [{:keys [name] :as property}]
+                 [name (check-temporal-property result property)]))
+         (into {}))))
+
+(comment
+
+  ;; TODO:
+  ;; - [x] Leads to
+  ;; - [x] For all
+  ;; - [x] Not
+  ;; - [ ] Always
+  ;; - [ ] Eventually
+  ;; - [ ] For some
+  ;; - [ ] Call
+  ;; - [ ] And*
+  ;; - [ ] Or*
+
+  ())

--- a/test/example/ewd_998.clj
+++ b/test/example/ewd_998.clj
@@ -145,10 +145,7 @@
                  #_ #_:workers 1
                  #_ #_:trace-example? true
                  :depth -1
-                 #_ #_:debug? true
-                 ;; If you are using :generate, :use-buffer is
-                 ;; set automatically.
-                 #_ #_:use-buffer true}
+                 #_ #_:debug? true}
                 (rh/with-features feature-flags
                   :generate {:generate {:num 10}}
                   {})))

--- a/test/example/scheduling_allocator.clj
+++ b/test/example/scheduling_allocator.clj
@@ -205,7 +205,7 @@ assuming that the clients scheduled earlier release their resources."
                {#_ #_:debug? true
                 #_ #_:workers 1})
 
-  (count (r/read-saved-data))
+  (r/read-saved-data :recife/violation)
   (r/halt!)
 
   ;; 3m20 to 47s (~4.25x) after the performance improvements!!

--- a/test/example/scheduling_allocator.clj
+++ b/test/example/scheduling_allocator.clj
@@ -201,13 +201,15 @@ assuming that the clients scheduled earlier release their resources."
                         ;; the current state (db) and the next state (db'). Uncomment
                         ;; below to see things failing when unsat is not different from
                         ;; unsat in the next state.
-                        #_action-prop}
+                        action-prop}
                {#_ #_:debug? true
                 #_ #_:workers 1})
 
+  (count (r/read-saved-data))
   (r/halt!)
 
   ;; 3m20 to 47s (~4.25x) after the performance improvements!!
   ;; 47s to 29s after adding keyword-cache
+  ;; 14s after fairness was fixed
 
   ())

--- a/test/example/scheduling_allocator.clj
+++ b/test/example/scheduling_allocator.clj
@@ -201,7 +201,7 @@ assuming that the clients scheduled earlier release their resources."
                         ;; the current state (db) and the next state (db'). Uncomment
                         ;; below to see things failing when unsat is not different from
                         ;; unsat in the next state.
-                        action-prop}
+                        #_action-prop}
                {#_ #_:debug? true
                 #_ #_:workers 1})
 

--- a/test/example/scheduling_allocator.clj
+++ b/test/example/scheduling_allocator.clj
@@ -237,7 +237,7 @@ assuming that the clients scheduled earlier release their resources."
                {#_ #_:debug? true
                 #_ #_:workers 1})
 
-  (r/get-result)
+  (def result (r/get-result))
   (r/read-saved-data :recife/violation)
   (r/halt!)
 
@@ -249,6 +249,24 @@ assuming that the clients scheduled earlier release their resources."
                                   allocator-invariant-3 allocator-invariant-4
                                   clients-will-return clients-will-obtain inf-often-satisfied
                                   [allocate-fairness return-fairness]})
+
+  (rh/defproperty clients-will-obtain
+    [{:keys [::unsat ::alloc]}]
+    (rh/and*
+     (rh/for-all [c clients]
+       (rh/for-all [r resources]
+         ;; We just add not*(s) here so we can test the temporal property checks,
+         ;; but the meaning is exactly the same as the original.
+         (rh/not*
+          (rh/not*
+           (rh/leads-to
+            (contains? (get unsat c) r)
+            (contains? (get alloc c) r))))))
+     (rh/for-some [c clients
+                   r resources]
+       (rh/leads-to
+        (contains? (get alloc c) r)
+        (contains? (get unsat c) r)))))
 
   ())
 

--- a/test/hillel/ch1_wire_1.clj
+++ b/test/hillel/ch1_wire_1.clj
@@ -36,8 +36,11 @@
 (comment
 
   (-> @(r/run-model global #{wire invariant} {#_ #_:raw-output? true
-                                             #_ #_:debug? true
-                                             #_ #_:run-local? true})
+                                              #_ #_:debug? true
+                                              #_ #_:run-local? true})
       r/timeline-diff)
+
+  (r/read-saved-data :recife/violation)
+  (r/get-result)
 
   ())

--- a/test/hillel/ch5_cache_3.clj
+++ b/test/hillel/ch5_cache_3.clj
@@ -57,8 +57,9 @@
   [db]
   ;; As this is just normal Clojure code, you can use whatever
   ;; libarry you want, e.g. `Malli` to check for your own schema.
-  (m/validate [:map [:cache/resource-cap int?
-                     :cache/resources-left int?]]
+  (m/validate [:map
+               [:cache/resource-cap :int]
+               [:cache/resources-left :int]]
               db))
 
 (comment

--- a/test/hillel/ch6_threads_3.clj
+++ b/test/hillel/ch6_threads_3.clj
@@ -84,14 +84,15 @@
 
   ;; back-to-state at around 30-32 states (back to 2-4)
   (def result
-    @(r/run-model global #{thread at-most-one-critical no-livelocks}
-                  {:workers 1
-                   :fp 0
-                   :seed 1
-                   #_ #_:simulate true
-                   #_ #_:run-local? true}))
+    (r/run-model global #{thread at-most-one-critical no-livelocks}
+                 {#_ #_:workers 1
+                  :fp 0
+                  :seed 1
+                  #_ #_:simulate true
+                  #_ #_:run-local? true}))
 
   (r/get-result)
+  (r/halt!)
   (ra/visualize-result result)
 
   ;; TODO:
@@ -114,6 +115,7 @@
   ;;   - [x] Get number of states checked and the number of traces
   ;;   - [x] For multiple workers, get first trace
   ;; - 19s achieved after removing TLA checks
+  ;; - 5s
   ;; - [ ] Check statistics http://conf.tlapl.us/2022/JackMarkusTLA+Statistics.pdf
   ;; - [ ] Create macro that sends data from chilren processes  to the current
   ;;       JVM

--- a/test/hillel/ch6_threads_3.clj
+++ b/test/hillel/ch6_threads_3.clj
@@ -84,16 +84,14 @@
 
   ;; back-to-state at around 30-32 states (back to 2-4)
   (def result
-    ;; When you have `:simulate` or `:generate` set as a truthy value,
-    ;; the return will be async. You can close or deref (@).
     @(r/run-model global #{thread at-most-one-critical no-livelocks}
                   {:workers 1
                    :fp 0
                    :seed 1
-                   :async true
                    #_ #_:simulate true
                    #_ #_:run-local? true}))
 
+  (r/get-result)
   (ra/visualize-result result)
 
   ;; TODO:

--- a/test/hillel_test.clj
+++ b/test/hillel_test.clj
@@ -449,7 +449,9 @@
                  :distinct-states 45
                  :generated-states 91
                  :seed 1
-                 :fp 0}
+                 :fp 0
+                 :experimental {:violated-temporal-properties
+                                #:hillel.ch6-threads-2{:no-livelocks {:violated? true}}}}
                 result))
     (simulate-assert result)))
 
@@ -924,6 +926,8 @@
             :generated-states nil
             :seed 1
             :fp 0
-            :simulation {:states-count 580 :traces-count 5}}
+            :simulation {:states-count 580 :traces-count 5}
+            :experimental {:violated-temporal-properties
+                           #:hillel.ch6-threads-3{:no-livelocks {:violated? true}}}}
            result))
     (simulate-assert result)))

--- a/test/recife/example/provenance.clj
+++ b/test/recife/example/provenance.clj
@@ -22,6 +22,6 @@
 ;; - [ ] Can we find multiple examples using TLC?
 ;;   - [x] Save violations
 ;;   - [x] Action property
+;;   - [x] Invariant
 ;;   - [ ] Temporal property
-;;   - [ ] Invariants
 ;; - [ ] Maybe can use core.logic for the traces?

--- a/test/recife/example/provenance.clj
+++ b/test/recife/example/provenance.clj
@@ -13,10 +13,23 @@
 ;; => (4 3)
 
 (def global
-  {})
+  {::q (r/one-of (range 10))
+   ::a (r/one-of (range 10))})
 
-(r/defproc try-read
-  (fn [{:keys [actor] :as db}]))
+(rh/defchecker member-of
+  [{::keys [a q]}]
+  (and (contains? #{1 4 3} a)
+       (contains? #{4 5 3} a)
+       (contains? #{7 8 q} a)))
+
+(comment
+
+  (r/run-model global #{member-of} {#_ #_:debug? true
+                                    #_ #_:workers 1})
+  (r/read-saved-data :recife/violation)
+  (r/halt!)
+
+  ())
 
 ;; TODO:
 ;; - [ ] Can we find multiple examples using TLC?
@@ -30,9 +43,9 @@
 ;;       - [x] Check traces
 ;;       - [ ] Use an action property for it, see
 ;;             https://github.com/tlaplus/tlaplus/issues/786#issuecomment-1407496531
-;;     - [ ] Do we have a way to know if a trace is "done" while
-;;           running the spec?
-;; - [ ] Maybe can use core.logic for the traces?
+;;   - [ ] Create continuous mode
+;;   - [ ] Test that the output is the same as the core logic one
+;; - [-] Maybe can use core.logic for the traces?
 
 ;; Instead of looking for violations, you may be
 ;; interested on the opposite, a trace example that satisfied some

--- a/test/recife/example/provenance.clj
+++ b/test/recife/example/provenance.clj
@@ -24,4 +24,18 @@
 ;;   - [x] Action property
 ;;   - [x] Invariant
 ;;   - [ ] Temporal property
+;;     - [ ] Check property violation using Clojure so we can find the correct
+;;           `defproperty`
+;;       - [ ] Compile rh functions to clojure when requested
+;;       - [ ] Accumulate state so we can show exactly where the error is located
+;;             inside the trace
+;;       - [ ] Check traces
+;;       - [ ] Use an action property for it, see
+;;             https://github.com/tlaplus/tlaplus/issues/786#issuecomment-1407496531
+;;     - [ ] Do we have a way to know if a trace is "done" while
+;;           running the spec?
 ;; - [ ] Maybe can use core.logic for the traces?
+
+;; Instead of looking for violations, you may be
+;; interested on the opposite, a trace example that satisfied some
+;; arbitrary condition.

--- a/test/recife/example/provenance.clj
+++ b/test/recife/example/provenance.clj
@@ -24,12 +24,10 @@
 ;;   - [x] Action property
 ;;   - [x] Invariant
 ;;   - [ ] Temporal property
-;;     - [ ] Check property violation using Clojure so we can find the correct
+;;     - [x] Check property violation using Clojure so we can find the correct
 ;;           `defproperty`
-;;       - [ ] Compile rh functions to clojure when requested
-;;       - [ ] Accumulate state so we can show exactly where the error is located
-;;             inside the trace
-;;       - [ ] Check traces
+;;       - [x] Compile rh functions to clojure when requested
+;;       - [x] Check traces
 ;;       - [ ] Use an action property for it, see
 ;;             https://github.com/tlaplus/tlaplus/issues/786#issuecomment-1407496531
 ;;     - [ ] Do we have a way to know if a trace is "done" while

--- a/test/recife/example/provenance.clj
+++ b/test/recife/example/provenance.clj
@@ -1,0 +1,27 @@
+(ns recife.example.provenance
+  (:require
+   [clojure.set :as set]
+   [recife.core :as r]
+   [recife.helpers :as rh]
+   [clojure.core.logic :as l]))
+
+#_(l/run* [q]
+    (l/fresh [a]
+      (l/membero a [1 4 3])
+      (l/membero a [4 5 3])
+      (l/membero a [7 8 q])))
+;; => (4 3)
+
+(def global
+  {})
+
+(r/defproc try-read
+  (fn [{:keys [actor] :as db}]))
+
+;; TODO:
+;; - [ ] Can we find multiple examples using TLC?
+;;   - [x] Save violations
+;;   - [x] Action property
+;;   - [ ] Temporal property
+;;   - [ ] Invariants
+;; - [ ] Maybe can use core.logic for the traces?

--- a/test/recife/example/provenance.clj
+++ b/test/recife/example/provenance.clj
@@ -13,21 +13,24 @@
 ;; => (4 3)
 
 (def global
-  {::q (r/one-of (range 10))
-   ::a (r/one-of (range 10))})
+  {::q (r/one-of (range 100))
+   ::a (r/one-of (range 100))})
 
 (rh/defchecker member-of
   [{::keys [a q]}]
-  (and (contains? #{1 4 3} a)
-       (contains? #{4 5 3} a)
-       (contains? #{7 8 q} a)))
+  (and (contains? (set [1 4 3]) a)
+       (contains? (set [4 5 3]) a)
+       (contains? (set [7 8 q]) a)))
 
 (comment
 
   (r/run-model global #{member-of} {#_ #_:debug? true
-                                    #_ #_:workers 1})
+                                    #_ #_:workers 1
+                                    :continue true})
+
+  ;; When you run above, you can see that it found the same `a` and `q`
+  ;; as found by core logic.
   (r/read-saved-data :recife/violation)
-  (r/halt!)
 
   ())
 
@@ -43,8 +46,7 @@
 ;;       - [x] Check traces
 ;;       - [ ] Use an action property for it, see
 ;;             https://github.com/tlaplus/tlaplus/issues/786#issuecomment-1407496531
-;;   - [ ] Create continuous mode
-;;   - [ ] Test that the output is the same as the core logic one
+;;   - [x] Test that the output is the same as the core logic one
 ;; - [-] Maybe can use core.logic for the traces?
 
 ;; Instead of looking for violations, you may be


### PR DESCRIPTION
- Add `defchecker`
- Add provenance example
- Check which temporal properties are violated (as TLC does not do it for us by default)